### PR TITLE
Use PIPE instead of capture_output to support python3.6

### DIFF
--- a/clang_tools/install.py
+++ b/clang_tools/install.py
@@ -10,7 +10,7 @@ import re
 import shutil
 import subprocess
 import sys
-from typing import Optional, Union
+from typing import Optional
 
 from . import install_os, RESET_COLOR, suffix, YELLOW
 from .util import download_file, verify_sha512, get_sha_checksum
@@ -38,7 +38,7 @@ def is_installed(tool_name: str, version: str) -> Optional[Path]:
     )
     try:
         result = subprocess.run(
-            [exe_name, "--version"], capture_output=True, check=True
+            [exe_name, "--version"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True
         )
     except (FileNotFoundError, subprocess.CalledProcessError):
         return None  # tool is not installed


### PR DESCRIPTION
Python 3.6 does not has `capture_output` https://docs.python.org/3.6/library/subprocess.html, use `subprocess.PIPE` instead can fix this problem. 

I have donwload new build wheel and install on my python3.6 env, it works now.

It would be best to include test on python3.6 with GitHub action if we support py36 in later release.


Fix #34