### PR TITLE
fix(docs): remove repo_type from conf.py

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -69,7 +69,6 @@ html_title = "clang-tools installer"
 html_theme_options = {
     "repo_url": "https://github.com/cpp-linter/clang-tools-pip",
     "repo_name": "clang-tools",
-    "repo_type": "github",
     "palette": [
         {
             "media": "(prefers-color-scheme: light)",


### PR DESCRIPTION
Since you have removed `repo_type` from https://github.com/jbms/sphinx-immaterial/pull/260
I assume build docs will also be failed like I have encountered [here](https://github.com/commit-check/commit-check/actions/runs/5317566147/jobs/9628219272)

```bash
preparing documents... failed

Warning, treated as error:
unsupported theme option 'repo_type' given
Error: Process completed with exit code 2.
```