### PR TITLE
refactor: move `release_tag` to `__init__.py`

### DIFF
--- a/clang_tools/__init__.py
+++ b/clang_tools/__init__.py
@@ -6,3 +6,6 @@ RESET_COLOR = "\033[0m"
 YELLOW = "\033[93m"
 install_os = check_install_os()
 suffix = ".exe" if install_os == "windows" else ""
+
+# tag of https://github.com/cpp-linter/clang-tools-static-binaries/releases
+release_tag = "master-be694ee7"

--- a/clang_tools/install.py
+++ b/clang_tools/install.py
@@ -11,6 +11,7 @@ import shutil
 import subprocess
 import sys
 from typing import Optional
+from . import release_tag
 
 from . import install_os, RESET_COLOR, suffix, YELLOW
 from .util import download_file, verify_sha512, get_sha_checksum
@@ -63,19 +64,19 @@ def is_installed(tool_name: str, version: str) -> Optional[Path]:
 
 
 def clang_tools_binary_url(
-    tool: str, version: str, release_tag: str = "master-be694ee7"
+    tool: str, version: str, tag: str = release_tag
 ) -> str:
     """Assemble the URL to the binary.
 
     :param tool: The name of the tool to download.
     :param version: The version of the tool to download.
-    :param release_tag: The release tag used in the base URL.
+    :param tag: The release tag used in the base URL.
 
     :returns: The URL used to download the specified tool.
     """
     base_url = (
         "https://github.com/cpp-linter/clang-tools-static-binaries/releases/download/"
-        + release_tag
+        + tag
     )
     download_url = f"{base_url}/{tool}-{version}_{install_os}-amd64{suffix}"
     return download_url.replace(" ", "")

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -4,6 +4,7 @@ import pytest
 from clang_tools import install_os
 from clang_tools.install import clang_tools_binary_url
 from clang_tools.util import check_install_os, download_file, get_sha_checksum
+from clang_tools import release_tag
 
 
 def test_check_install_os():
@@ -13,12 +14,12 @@ def test_check_install_os():
 
 
 @pytest.mark.parametrize(
-    "tag", ["master-be694ee7", pytest.param("latest", marks=pytest.mark.xfail)]
+    "tag", [release_tag, pytest.param("latest", marks=pytest.mark.xfail)]
 )
 def test_download_file(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, tag: str):
     """Test that deliberately fails to download a file."""
     monkeypatch.chdir(str(tmp_path))
-    url = clang_tools_binary_url("clang-format", "12", release_tag=tag)
+    url = clang_tools_binary_url("clang-format", "12", tag=release_tag)
     file_name = download_file(url, "file.tar.gz", True)
     assert file_name is not None
 
@@ -30,5 +31,5 @@ def test_get_sha(monkeypatch: pytest.MonkeyPatch):
     expected = Path(f"clang-format-12_{install_os}-amd64.sha512sum").read_text(
         encoding="utf-8"
     )
-    url = clang_tools_binary_url("clang-format", "12", release_tag="master-be694ee7")
+    url = clang_tools_binary_url("clang-format", "12", tag=release_tag)
     assert get_sha_checksum(url) == expected


### PR DESCRIPTION
to easily manage the release of https://github.com/cpp-linter/clang-tools-static-binaries/releases

I moved `release_tag` to `__init__.py`