### PR TITLE
update release_tag

### DIFF
--- a/clang_tools/__init__.py
+++ b/clang_tools/__init__.py
@@ -8,4 +8,4 @@ install_os = check_install_os()
 suffix = ".exe" if install_os == "windows" else ""
 
 # tag of https://github.com/cpp-linter/clang-tools-static-binaries/releases
-release_tag = "master-03a926cf"
+release_tag = "master-2e4f8c1f"


### PR DESCRIPTION
just to test the new static binary builds in pre-release [master-2e4f8c1f](https://github.com/cpp-linter/clang-tools-static-binaries/releases/tag/untagged-52523c2d691218f6b7cf)