### PR TITLE
fix test CI workflow

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -46,6 +46,7 @@ jobs:
         with:
           name: coverage-data-${{ runner.os }}
           path: .coverage*
+          include-hidden-files: true
 
   coverage-report:
     needs: [test]


### PR DESCRIPTION
This fixes the test CI workflow.

Apparently, hidden files (like `.coverage*`) are excluded from artifact uploads now. This reverts that behavior using the `actions/upload-artifact`'s new input `include-hidden-files`.