### PR TITLE
Replace deprecated classifier with licence expression (PEP 639)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,6 @@ description = "Install clang-tools (clang-format, clang-tidy, clang-query, clang
 readme = "README.rst"
 keywords = ["clang", "clang-tools", "clang-extra", "clang-tidy", "clang-format", "clang-query", "clang-apply-replacements"]
 license = "MIT"
-license-files = [ "LICENSE" ]
 authors = [
     { name = "Xianpeng Shen", email = "xianpeng.shen@gmail.com" },
     { name = "Brendan Doherty", email = "2bndy5@gmail.com" },


### PR DESCRIPTION
Same as https://github.com/cpp-linter/cpp-linter/pull/136

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated the project’s licensing metadata by simplifying the license declaration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->