### PR TITLE
chore: move deps from `requirements-dev.txt` to `pyproject.toml`

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Install dependencies
         run: |
           python3 -m pip install --upgrade pip
-          python3 -m pip install . -r requirements-dev.txt
+          python3 -m pip install .[dev]
 
       - name: Collect Coverage
         run: coverage run -m pytest -vv

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -4,6 +4,5 @@
 
 tasks:
   - name: Setup & Install
-    before: pip install -r requirements-dev.txt
+    before: pip install -e .[dev]
     init: pre-commit install
-    command: pip install -e .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,8 +38,12 @@ clang-tools = "clang_tools.main:main"
 source =  "https://github.com/cpp-linter/clang-tools-pip"
 tracker = "https://github.com/cpp-linter/clang-tools-pip/issues"
 
-# ... other project metadata fields as specified in:
-#     https://packaging.python.org/en/latest/specifications/declaring-project-metadata/
+[project.optional-dependencies]
+dev = [
+    "coverage[toml]",
+    "pre-commit",
+    "pytest",
+]
 
 [tool.setuptools]
 zip-safe = false

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,0 @@
-coverage[toml]
-flake8
-pre-commit
-pytest


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated development dependency management to use a standardized extras group, simplifying installation commands.
  - Removed the separate development requirements file.
  - Updated workflow and environment setup instructions to reflect these changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->