### PR TITLE
chore(dev): switch `macos-latest` CI runner

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,7 +75,7 @@ jobs:
     strategy:
       matrix:
         version: [ 9, 10, 11, 12, 12.0.1, 13, 14, 15, 16, 17, 18, 19, 20, 21 ]
-        os: [ ubuntu-latest, macos-13, windows-latest ]
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Macos-13 is deprecated and currently get phased out.