### PR TITLE
chore: add cpp-linter hub badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![SonarCloud](https://sonarcloud.io/api/project_badges/measure?project=cpp-linter_clang-tools-pip&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=cpp-linter_clang-tools-pip)
 [![Platform](https://img.shields.io/badge/platform-linux--64%20%7C%20linux--arm64%20%7C%20win--64%20%7C%20osx--64%20%7C%20osx--arm64%20-blue)](https://pypi.org/project/clang-tools/)
 [![Downloads](https://img.shields.io/pypi/dw/clang-tools)](https://pypistats.org/packages/clang-tools)
+[![cpp-linter hub](https://img.shields.io/badge/%F0%9F%8F%A0_cpp--linter_hub-%E2%86%90_home-22863a)](https://cpp-linter.github.io/)
 
 Easily install `clang-format`, `clang-tidy`, `clang-query`, and
 `clang-apply-replacements` static binaries or Python wheels using the


### PR DESCRIPTION
## Summary

Adds the `🏠 cpp-linter hub ← home` badge for consistent cross-repo navigation back to [cpp-linter.github.io](https://cpp-linter.github.io/).

Part of org-wide Phase 2 documentation consistency improvements.

## Changes

- Added hub badge to the badge row in README.md