### PR TITLE
feat: unify CLI entry point - eliminate binary/wheel split

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,7 +96,7 @@ jobs:
         run: pip install --no-cache-dir dist/*.whl
 
       - name: Install clang-tools binaries
-        run: clang-tools --install ${{ matrix.version }} --tool clang-format clang-tidy clang-query clang-apply-replacements
+        run: clang-tools install ${{ matrix.version }} --tool clang-format clang-tidy clang-query clang-apply-replacements
 
       - name: Show path of clang-tools binaries
         shell: bash
@@ -145,7 +145,7 @@ jobs:
         shell: bash
         run: |
           set -e
-          clang-tools-wheel --tool clang-format --version ${{ matrix.version }}
+          clang-tools install clang-format --wheel --version ${{ matrix.version }}
 
           echo "Checking clang-format versions..."
           clang-format --version
@@ -167,7 +167,7 @@ jobs:
         shell: bash
         run: |
           set -e
-          clang-tools-wheel --tool clang-tidy --version ${{ matrix.version }}
+          clang-tools install clang-tidy --wheel --version ${{ matrix.version }}
 
           echo "Checking clang-tidy versions..."
           clang-tidy --version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,23 +17,6 @@ on:
 
 
 jobs:
-  security:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  #v6.0.3
-
-      - name: Set up Python 3.10
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 #v6.2.0
-        with:
-          python-version: "3.10"
-
-      - name: Install Bandit
-        run: python3 -m pip install "bandit[toml]"
-
-      - name: Run Bandit security scan
-        continue-on-error: true
-        run: bandit -c pyproject.toml -r clang_tools/
-
   test:
     strategy:
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,23 @@ on:
 
 
 jobs:
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  #v6.0.3
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 #v6.2.0
+        with:
+          python-version: "3.10"
+
+      - name: Install Bandit
+        run: python3 -m pip install "bandit[toml]"
+
+      - name: Run Bandit security scan
+        continue-on-error: true
+        run: bandit -c pyproject.toml -r clang_tools/
+
   test:
     strategy:
       matrix:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,12 +21,6 @@ repos:
     hooks:
       - id: ruff-check
       - id: ruff-format
-  - repo: https://github.com/PyCQA/bandit
-    rev: 1.8.4
-    hooks:
-      - id: bandit
-        args: ["-c", "pyproject.toml"]
-        additional_dependencies: ["bandit[toml]"]
   # - repo: local
   #   hooks:
   #     - id: pytest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,6 +21,12 @@ repos:
     hooks:
       - id: ruff-check
       - id: ruff-format
+  - repo: https://github.com/PyCQA/bandit
+    rev: 1.8.4
+    hooks:
+      - id: bandit
+        args: ["-c", "pyproject.toml"]
+        additional_dependencies: ["bandit[toml]"]
   # - repo: local
   #   hooks:
   #     - id: pytest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,10 +18,10 @@ Install `clang-tools` from source code
 
 ```bash
 $ git clone git@github.com:cpp-linter/clang-tools-pip.git
-# Need root permission
-$ sudo python3 setup.py install
+$ cd clang-tools-pip
+$ pip install -e .
 # Install clang-tools version 13
-$ sudo python3 main.py --install true --version 13
+$ clang-tools install 13
 ```
 
 ### Test

--- a/README.md
+++ b/README.md
@@ -71,14 +71,17 @@ For a full list of CLI options, see the [documentation](https://cpp-linter.githu
 ### Install binaries
 
 ```bash
-# Install version 13 binaries
-clang-tools --install 13
+# Install version 13 binaries (auto-detects binary vs wheel)
+clang-tools install 13
+
+# Force binary installation
+clang-tools install 13 --binary
 
 # Install to a specified directory
-clang-tools --install 13 --directory .
+clang-tools install 13 --directory .
 
 # Install specific tools
-clang-tools --install 14 --tool clang-format clang-query
+clang-tools install 14 --tool clang-format clang-query
 ```
 
 If the installed directory is in your path:
@@ -92,14 +95,14 @@ clang-format-13 --version
 
 ```bash
 # Install latest clang-format wheel
-clang-tools-wheel --tool clang-format
+clang-tools install clang-format --wheel
 
 # Install specific version
-clang-tools-wheel --tool clang-format --version 21
+clang-tools install clang-format --wheel --version 21
 ```
 
 > [!IMPORTANT]
-> The `clang-tools-wheel` command is primarily intended for
+> Wheel installation is primarily intended for
 > cpp-linter projects. For general use, install wheels directly
 > using `pip`, `pipx`, or `uv`.
 

--- a/clang_tools/install.py
+++ b/clang_tools/install.py
@@ -261,7 +261,11 @@ def uninstall_clang_tools(tools: list[str], version: str, directory: str):
 
 
 def install_clang_tools(
-    version: Version, tools: list[str], directory: str, overwrite: bool, no_progress_bar: bool
+    version: Version,
+    tools: list[str],
+    directory: str,
+    overwrite: bool,
+    no_progress_bar: bool,
 ) -> None:
     """Wraps functions used to individually install tools.
 

--- a/clang_tools/install.py
+++ b/clang_tools/install.py
@@ -247,7 +247,7 @@ def uninstall_tool(tool_name: str, version: str, directory: str):
         symlink.unlink()
 
 
-def uninstall_clang_tools(tools: str, version: str, directory: str):
+def uninstall_clang_tools(tools: list[str], version: str, directory: str):
     """Uninstall a clang tool of a given version.
 
     :param version: The version of the clang-tools to remove.
@@ -261,7 +261,7 @@ def uninstall_clang_tools(tools: str, version: str, directory: str):
 
 
 def install_clang_tools(
-    version: Version, tools: str, directory: str, overwrite: bool, no_progress_bar: bool
+    version: Version, tools: list[str], directory: str, overwrite: bool, no_progress_bar: bool
 ) -> None:
     """Wraps functions used to individually install tools.
 

--- a/clang_tools/install.py
+++ b/clang_tools/install.py
@@ -250,6 +250,7 @@ def uninstall_tool(tool_name: str, version: str, directory: str):
 def uninstall_clang_tools(tools: list[str], version: str, directory: str):
     """Uninstall a clang tool of a given version.
 
+    :param tools: The list of tool names to uninstall.
     :param version: The version of the clang-tools to remove.
     :param directory: The directory from which to remove the
         installed clang-tools.

--- a/clang_tools/main.py
+++ b/clang_tools/main.py
@@ -258,7 +258,7 @@ def main() -> int:
         return 0
 
     if args.command == "uninstall":
-        uninstall_clang_tools(args.version, args.tool, args.directory)
+        uninstall_clang_tools(args.tool, args.version, args.directory)
         return 0
 
     if args.command == "install":

--- a/clang_tools/main.py
+++ b/clang_tools/main.py
@@ -12,7 +12,7 @@ import sys
 from typing import Optional
 
 from .install import install_clang_tools, uninstall_clang_tools
-from . import RESET_COLOR, YELLOW, MIN_VERSION, MAX_VERSION
+from . import RESET_COLOR, YELLOW
 from .util import Version
 
 
@@ -49,6 +49,118 @@ def _wheel_install(tools: list[str], version: Optional[str]) -> int:
             print(f"Failed to install {tool}{version_str}", file=sys.stderr)
             ok = False
     return 0 if ok else 1
+
+
+def _validate_wheel_tool(target: str) -> bool:
+    """Print an error and return `False` if *target* is not a wheel tool.
+    """
+    if target not in WHEEL_TOOLS:
+        print(
+            f"{YELLOW}Error: '{target}' is not available as a"
+            f" wheel. Supported: "
+            f"{', '.join(sorted(WHEEL_TOOLS))}{RESET_COLOR}",
+            file=sys.stderr,
+        )
+        return False
+    return True
+
+
+def _handle_wheel(args: argparse.Namespace) -> int:
+    """Handle ``install --wheel`` subcommand."""
+    target: str = args.target
+    if _is_version_like(target):
+        return _wheel_install(args.tool, target)
+    if not _validate_wheel_tool(target):
+        return 1
+    return _wheel_install([target], args.explicit_version)
+
+
+def _handle_binary(args: argparse.Namespace) -> int:
+    """Handle ``install --binary`` subcommand."""
+    target: str = args.target
+    if not _is_version_like(target):
+        print(
+            f"{YELLOW}Error: --binary requires a version number"
+            f" (got '{target}'){RESET_COLOR}",
+            file=sys.stderr,
+        )
+        return 1
+    version = Version(target)
+    if version.info == (0, 0, 0):
+        print(
+            f"{YELLOW}The version specified is not a semantic"
+            f" specification{RESET_COLOR}",
+            file=sys.stderr,
+        )
+        return 1
+    install_clang_tools(
+        version,
+        args.tool,
+        args.directory,
+        args.overwrite,
+        args.no_progress_bar,
+    )
+    return 0
+
+
+def _handle_auto_detect(args: argparse.Namespace) -> int:
+    """Handle ``install`` without --binary/--wheel (auto-detect mode)."""
+    target: str = args.target
+    if not _is_version_like(target):
+        if target not in WHEEL_TOOLS:
+            print(
+                f"{YELLOW}Unknown target '{target}'. Expected a"
+                f" version number or one of: "
+                f"{', '.join(sorted(WHEEL_TOOLS))}{RESET_COLOR}",
+                file=sys.stderr,
+            )
+            return 1
+        return _wheel_install([target], args.explicit_version)
+
+    version = Version(target)
+    if version.info == (0, 0, 0):
+        print(
+            f"{YELLOW}The version specified is not a semantic"
+            f" specification{RESET_COLOR}",
+            file=sys.stderr,
+        )
+        return 1
+
+    # try binary first, fall back to wheel
+    try:
+        install_clang_tools(
+            version,
+            args.tool,
+            args.directory,
+            args.overwrite,
+            args.no_progress_bar,
+        )
+        return 0
+    except (OSError, ValueError, SystemExit) as exc:
+        print(
+            f"{YELLOW}Binary install failed"
+            f" ({exc}), falling back to"
+            f" wheel...{RESET_COLOR}",
+            file=sys.stderr,
+        )
+    return _wheel_install(args.tool, target)
+
+
+def _handle_install(args: argparse.Namespace) -> int:
+    """Dispatch ``install`` subcommand based on flags."""
+    if args.binary and args.wheel:
+        print(
+            f"{YELLOW}Error: --binary and --wheel are mutually"
+            f" exclusive{RESET_COLOR}",
+            file=sys.stderr,
+        )
+        return 1
+
+    if args.wheel:
+        return _handle_wheel(args)
+    if args.binary:
+        return _handle_binary(args)
+    return _handle_auto_detect(args)
 
 
 def get_parser() -> argparse.ArgumentParser:
@@ -139,7 +251,6 @@ def main() -> int:
     parser = get_parser()
     args = parser.parse_args()
 
-    # ---- No subcommand → nothing to do ----------------------------------
     if args.command is None:
         print(
             f"{YELLOW}Nothing to do. Use 'install' or 'uninstall'"
@@ -149,110 +260,12 @@ def main() -> int:
         parser.print_help()
         return 0
 
-    # ---- ``uninstall`` subcommand ------------------------------------
     if args.command == "uninstall":
         uninstall_clang_tools(args.version, args.tool, args.directory)
         return 0
 
-    # ---- ``install`` subcommand --------------------------------------
     if args.command == "install":
-        target: str = args.target
-        binary: bool = args.binary
-        wheel: bool = args.wheel
-
-        # safety: --binary and --wheel are mutually exclusive
-        if binary and wheel:
-            print(
-                f"{YELLOW}Error: --binary and --wheel are mutually"
-                f" exclusive{RESET_COLOR}",
-                file=sys.stderr,
-            )
-            return 1
-
-        # ---- Case: --wheel (target may be tool name or version) -----
-        if wheel:
-            if _is_version_like(target):
-                # ``clang-tools install 18 --wheel``
-                return _wheel_install(args.tool, target)
-            else:
-                # ``clang-tools install clang-format --wheel``
-                if target not in WHEEL_TOOLS:
-                    print(
-                        f"{YELLOW}Error: '{target}' is not available as a"
-                        f" wheel. Supported: "
-                        f"{', '.join(sorted(WHEEL_TOOLS))}{RESET_COLOR}",
-                        file=sys.stderr,
-                    )
-                    return 1
-                return _wheel_install([target], args.explicit_version)
-
-        # ---- Case: --binary (target must be a version) --------------
-        if binary:
-            if not _is_version_like(target):
-                print(
-                    f"{YELLOW}Error: --binary requires a version number"
-                    f" (got '{target}'){RESET_COLOR}",
-                    file=sys.stderr,
-                )
-                return 1
-            version = Version(target)
-            if version.info != (0, 0, 0):
-                install_clang_tools(
-                    version,
-                    args.tool,
-                    args.directory,
-                    args.overwrite,
-                    args.no_progress_bar,
-                )
-                return 0
-            print(
-                f"{YELLOW}The version specified is not a semantic"
-                f" specification{RESET_COLOR}",
-                file=sys.stderr,
-            )
-            return 1
-
-        # ---- Auto-detect (no --binary or --wheel flag) --------------
-        if _is_version_like(target):
-            version = Version(target)
-            if version.info != (0, 0, 0):
-                # try binary first, fall back to wheel
-                try:
-                    install_clang_tools(
-                        version,
-                        args.tool,
-                        args.directory,
-                        args.overwrite,
-                        args.no_progress_bar,
-                    )
-                    return 0
-                except Exception as exc:
-                    print(
-                        f"{YELLOW}Binary install failed"
-                        f" ({exc}), falling back to"
-                        f" wheel...{RESET_COLOR}",
-                        file=sys.stderr,
-                    )
-                # fallback to wheel
-                return _wheel_install(args.tool, target)
-            else:
-                print(
-                    f"{YELLOW}The version specified is not a semantic"
-                    f" specification{RESET_COLOR}",
-                    file=sys.stderr,
-                )
-                return 1
-        else:
-            # target is a tool name → install via wheel
-            if target not in WHEEL_TOOLS:
-                print(
-                    f"{YELLOW}Unknown target '{target}'. Expected a"
-                    f" version number or one of: "
-                    f"{', '.join(sorted(WHEEL_TOOLS))}{RESET_COLOR}",
-                    file=sys.stderr,
-                )
-                return 1
-            return _wheel_install([target], args.explicit_version)
+        return _handle_install(args)
 
     return 0  # unreachable
 

--- a/clang_tools/main.py
+++ b/clang_tools/main.py
@@ -29,9 +29,7 @@ def _is_version_like(target: str) -> bool:
 
 
 #: Known tool names supported by wheel installs
-WHEEL_TOOLS = {
-    "clang-format", "clang-tidy", "clang-query", "clang-apply-replacements",
-}
+WHEEL_TOOLS = {"clang-format", "clang-tidy"}
 
 
 def _wheel_install(tools: list[str], version: Optional[str]) -> int:
@@ -178,6 +176,14 @@ def main() -> int:
                 return _wheel_install(args.tool, target)
             else:
                 # ``clang-tools install clang-format --wheel``
+                if target not in WHEEL_TOOLS:
+                    print(
+                        f"{YELLOW}Error: '{target}' is not available as a"
+                        f" wheel. Supported: "
+                        f"{', '.join(sorted(WHEEL_TOOLS))}{RESET_COLOR}",
+                        file=sys.stderr,
+                    )
+                    return 1
                 return _wheel_install([target], args.explicit_version)
 
         # ---- Case: --binary (target must be a version) --------------

--- a/clang_tools/main.py
+++ b/clang_tools/main.py
@@ -32,7 +32,10 @@ WHEEL_TOOLS = {"clang-format", "clang-tidy"}
 
 
 def _wheel_install(tools: list[str], version: Optional[str]) -> int:
-    """Install tool(s) via wheel (cpp_linter_hooks).
+    """Install tool(s) as Python wheels using ``cpp_linter_hooks``.
+
+    Delegates to :func:`cpp_linter_hooks.util.resolve_install` for version
+    resolution and pip-based installation.
 
     :returns: exit code (0 on success, 1 on failure).
     """

--- a/clang_tools/main.py
+++ b/clang_tools/main.py
@@ -17,8 +17,7 @@ from .util import Version
 
 
 def _is_version_like(target: str) -> bool:
-    """Check if *target* looks like a version number (e.g. ``"18"``, ``"18.1"``).
-    """
+    """Check if *target* looks like a version number (e.g. ``"18"``, ``"18.1"``)."""
     try:
         parts = target.split(".")
         for p in parts:
@@ -52,8 +51,7 @@ def _wheel_install(tools: list[str], version: Optional[str]) -> int:
 
 
 def _validate_wheel_tool(target: str) -> bool:
-    """Print an error and return `False` if *target* is not a wheel tool.
-    """
+    """Print an error and return `False` if *target* is not a wheel tool."""
     if target not in WHEEL_TOOLS:
         print(
             f"{YELLOW}Error: '{target}' is not available as a"
@@ -150,8 +148,7 @@ def _handle_install(args: argparse.Namespace) -> int:
     """Dispatch ``install`` subcommand based on flags."""
     if args.binary and args.wheel:
         print(
-            f"{YELLOW}Error: --binary and --wheel are mutually"
-            f" exclusive{RESET_COLOR}",
+            f"{YELLOW}Error: --binary and --wheel are mutually exclusive{RESET_COLOR}",
             file=sys.stderr,
         )
         return 1

--- a/clang_tools/main.py
+++ b/clang_tools/main.py
@@ -134,7 +134,7 @@ def _handle_auto_detect(args: argparse.Namespace) -> int:
             args.no_progress_bar,
         )
         return 0
-    except (OSError, ValueError, SystemExit) as exc:
+    except (OSError, ValueError) as exc:
         print(
             f"{YELLOW}Binary install failed"
             f" ({exc}), falling back to"

--- a/clang_tools/main.py
+++ b/clang_tools/main.py
@@ -9,6 +9,7 @@ via a single ``clang-tools`` command.
 
 import argparse
 import sys
+from typing import Optional
 
 from .install import install_clang_tools, uninstall_clang_tools
 from . import RESET_COLOR, YELLOW, MIN_VERSION, MAX_VERSION
@@ -28,10 +29,12 @@ def _is_version_like(target: str) -> bool:
 
 
 #: Known tool names supported by wheel installs
-WHEEL_TOOLS = {"clang-format", "clang-tidy", "clang-query", "clang-apply-replacements"}
+WHEEL_TOOLS = {
+    "clang-format", "clang-tidy", "clang-query", "clang-apply-replacements",
+}
 
 
-def _wheel_install(tools: list[str], version: str | None) -> int:
+def _wheel_install(tools: list[str], version: Optional[str]) -> int:
     """Install tool(s) via wheel (cpp_linter_hooks).
 
     :returns: exit code (0 on success, 1 on failure).
@@ -55,56 +58,6 @@ def get_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description="Install and manage clang-tools (clang-format, clang-tidy, etc.)"
     )
-
-    # ------------------------------------------------------------------
-    #  Backward-compatible top-level flags (deprecated – kept for
-    #  compatibility with older scripts / workflows)
-    # ------------------------------------------------------------------
-    parser.add_argument(
-        "-i",
-        "--install",
-        metavar="VERSION",
-        help="(deprecated) Use 'clang-tools install <version>' instead",
-        dest="_legacy_install",
-    )
-    parser.add_argument(
-        "-u",
-        "--uninstall",
-        metavar="VERSION",
-        help="(deprecated) Use 'clang-tools uninstall <version>' instead",
-        dest="_legacy_uninstall",
-    )
-    parser.add_argument(
-        "-t",
-        "--tool",
-        nargs="+",
-        default=["clang-format", "clang-tidy"],
-        metavar="TOOL",
-        help="Specify which tool(s) to install.",
-    )
-    parser.add_argument(
-        "-d",
-        "--directory",
-        default="",
-        metavar="DIR",
-        help="The directory where the clang-tools are installed.",
-    )
-    parser.add_argument(
-        "-f",
-        "--overwrite",
-        action="store_true",
-        help="Force overwriting the symlink to the installed binary.",
-    )
-    parser.add_argument(
-        "-b",
-        "--no-progress-bar",
-        action="store_true",
-        help="Do not display a progress bar for downloads.",
-    )
-
-    # ------------------------------------------------------------------
-    #  Subcommands (new-style CLI)
-    # ------------------------------------------------------------------
     subparsers = parser.add_subparsers(dest="command", help="Available commands")
 
     # --- ``clang-tools install <target>`` ---------------------------------
@@ -188,36 +141,11 @@ def main() -> int:
     parser = get_parser()
     args = parser.parse_args()
 
-    # ---- Legacy backward-compat path ----------------------------------
-    if args._legacy_uninstall or args._legacy_install:
-        if args._legacy_uninstall:
-            uninstall_clang_tools(
-                args._legacy_uninstall, args.tool, args.directory
-            )
-        if args._legacy_install:
-            version = Version(args._legacy_install)
-            if version.info != (0, 0, 0):
-                install_clang_tools(
-                    version,
-                    args.tool,
-                    args.directory,
-                    args.overwrite,
-                    args.no_progress_bar,
-                )
-            else:
-                print(
-                    f"{YELLOW}The version specified is not a semantic",
-                    f"specification{RESET_COLOR}",
-                    file=sys.stderr,
-                )
-                return 1
-        return 0
-
-    # ---- No subcommand, no legacy flags → nothing to do --------------
+    # ---- No subcommand → nothing to do ----------------------------------
     if args.command is None:
         print(
-            f"{YELLOW}Nothing to do. Use 'install' or 'uninstall' subcommand,"
-            f" or --install/--uninstall flags.{RESET_COLOR}",
+            f"{YELLOW}Nothing to do. Use 'install' or 'uninstall'"
+            f" subcommand.{RESET_COLOR}",
             file=sys.stderr,
         )
         parser.print_help()
@@ -250,7 +178,6 @@ def main() -> int:
                 return _wheel_install(args.tool, target)
             else:
                 # ``clang-tools install clang-format --wheel``
-                # Install the target as the tool (ignore default --tool)
                 return _wheel_install([target], args.explicit_version)
 
         # ---- Case: --binary (target must be a version) --------------

--- a/clang_tools/main.py
+++ b/clang_tools/main.py
@@ -2,27 +2,77 @@
 ``clang_tools.main``
 --------------------
 
-The module containing main entrypoint function.
+The module containing the unified main entrypoint function.
+Supports both binary (static build) and wheel-based installation
+via a single ``clang-tools`` command.
 """
 
 import argparse
+import sys
 
 from .install import install_clang_tools, uninstall_clang_tools
-from . import RESET_COLOR, YELLOW
+from . import RESET_COLOR, YELLOW, MIN_VERSION, MAX_VERSION
 from .util import Version
 
 
-def get_parser() -> argparse.ArgumentParser:
-    """Get and parser to interpret CLI args."""
-    parser = argparse.ArgumentParser()
+def _is_version_like(target: str) -> bool:
+    """Check if *target* looks like a version number (e.g. ``"18"``, ``"18.1"``).
+    """
+    try:
+        parts = target.split(".")
+        for p in parts:
+            int(p)
+        return True
+    except ValueError:
+        return False
 
+
+#: Known tool names supported by wheel installs
+WHEEL_TOOLS = {"clang-format", "clang-tidy", "clang-query", "clang-apply-replacements"}
+
+
+def _wheel_install(tools: list[str], version: str | None) -> int:
+    """Install tool(s) via wheel (cpp_linter_hooks).
+
+    :returns: exit code (0 on success, 1 on failure).
+    """
+    from cpp_linter_hooks.util import resolve_install  # lazy import
+
+    ok = True
+    for tool in tools:
+        path = resolve_install(tool, version)
+        version_str = f" version {version}" if version else " latest version"
+        if path:
+            print(f"{tool}{version_str} installed at: {path}")
+        else:
+            print(f"Failed to install {tool}{version_str}", file=sys.stderr)
+            ok = False
+    return 0 if ok else 1
+
+
+def get_parser() -> argparse.ArgumentParser:
+    """Get a parser to interpret CLI args (unified entry point)."""
+    parser = argparse.ArgumentParser(
+        description="Install and manage clang-tools (clang-format, clang-tidy, etc.)"
+    )
+
+    # ------------------------------------------------------------------
+    #  Backward-compatible top-level flags (deprecated – kept for
+    #  compatibility with older scripts / workflows)
+    # ------------------------------------------------------------------
     parser.add_argument(
         "-i",
         "--install",
         metavar="VERSION",
-        help="Install clang-tools about a specific version. This can be in the form of"
-        " a semantic version specification (``x.y.z``, ``x.y``, ``x``). NOTE: A "
-        "malformed version specification will cause a silent failure.",
+        help="(deprecated) Use 'clang-tools install <version>' instead",
+        dest="_legacy_install",
+    )
+    parser.add_argument(
+        "-u",
+        "--uninstall",
+        metavar="VERSION",
+        help="(deprecated) Use 'clang-tools uninstall <version>' instead",
+        dest="_legacy_uninstall",
     )
     parser.add_argument(
         "-t",
@@ -43,8 +93,7 @@ def get_parser() -> argparse.ArgumentParser:
         "-f",
         "--overwrite",
         action="store_true",
-        help="Force overwriting the symlink to the installed binary. This will only "
-        "overwrite an existing symlink.",
+        help="Force overwriting the symlink to the installed binary.",
     )
     parser.add_argument(
         "-b",
@@ -52,45 +101,228 @@ def get_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Do not display a progress bar for downloads.",
     )
-    parser.add_argument(
-        "-u",
-        "--uninstall",
-        metavar="VERSION",
-        help="Uninstall clang-tools with specific version. "
-        "This is done before any install.",
+
+    # ------------------------------------------------------------------
+    #  Subcommands (new-style CLI)
+    # ------------------------------------------------------------------
+    subparsers = parser.add_subparsers(dest="command", help="Available commands")
+
+    # --- ``clang-tools install <target>`` ---------------------------------
+    install_p = subparsers.add_parser("install", help="Install clang-tools")
+    install_p.add_argument(
+        "target",
+        help="Version number (e.g. 18) or tool name (e.g. clang-format)",
     )
+    install_p.add_argument(
+        "--binary",
+        action="store_true",
+        help="Force binary (static build) installation",
+    )
+    install_p.add_argument(
+        "--wheel",
+        action="store_true",
+        help="Force wheel installation via cpp-linter-hooks",
+    )
+    install_p.add_argument(
+        "--version",
+        dest="explicit_version",
+        default=None,
+        metavar="VER",
+        help="Explicit version for wheel install (when target is a tool name)",
+    )
+    install_p.add_argument(
+        "-t",
+        "--tool",
+        nargs="+",
+        default=["clang-format", "clang-tidy"],
+        metavar="TOOL",
+        help="Specify which tool(s) to install.",
+    )
+    install_p.add_argument(
+        "-d",
+        "--directory",
+        default="",
+        metavar="DIR",
+        help="The directory where the clang-tools are installed.",
+    )
+    install_p.add_argument(
+        "-f",
+        "--overwrite",
+        action="store_true",
+        help="Force overwriting the symlink to the installed binary.",
+    )
+    install_p.add_argument(
+        "-b",
+        "--no-progress-bar",
+        action="store_true",
+        help="Do not display a progress bar for downloads.",
+    )
+
+    # --- ``clang-tools uninstall <version>`` ------------------------------
+    uninstall_p = subparsers.add_parser("uninstall", help="Uninstall clang-tools")
+    uninstall_p.add_argument("version", help="Version to uninstall")
+    uninstall_p.add_argument(
+        "-t",
+        "--tool",
+        nargs="+",
+        default=["clang-format", "clang-tidy"],
+        metavar="TOOL",
+        help="Specify which tool(s) to uninstall.",
+    )
+    uninstall_p.add_argument(
+        "-d",
+        "--directory",
+        default="",
+        metavar="DIR",
+        help="The directory from which to uninstall the tools.",
+    )
+
     return parser
 
 
-def main():
-    """The main entrypoint to the CLI program."""
+def main() -> int:
+    """Unified entry point for the CLI program.
+
+    :returns: exit code (0 on success, 1 on failure).
+    """
     parser = get_parser()
     args = parser.parse_args()
 
-    if args.uninstall:
-        uninstall_clang_tools(args.uninstall, args.tool, args.directory)
-    elif args.install:
-        version = Version(args.install)
-        if version.info != (0, 0, 0):
-            install_clang_tools(
-                version,
-                args.tool,
-                args.directory,
-                args.overwrite,
-                args.no_progress_bar,
+    # ---- Legacy backward-compat path ----------------------------------
+    if args._legacy_uninstall or args._legacy_install:
+        if args._legacy_uninstall:
+            uninstall_clang_tools(
+                args._legacy_uninstall, args.tool, args.directory
             )
-        else:
-            print(
-                f"{YELLOW}The version specified is not a semantic",
-                f"specification{RESET_COLOR}",
-            )
-    else:
+        if args._legacy_install:
+            version = Version(args._legacy_install)
+            if version.info != (0, 0, 0):
+                install_clang_tools(
+                    version,
+                    args.tool,
+                    args.directory,
+                    args.overwrite,
+                    args.no_progress_bar,
+                )
+            else:
+                print(
+                    f"{YELLOW}The version specified is not a semantic",
+                    f"specification{RESET_COLOR}",
+                    file=sys.stderr,
+                )
+                return 1
+        return 0
+
+    # ---- No subcommand, no legacy flags → nothing to do --------------
+    if args.command is None:
         print(
-            f"{YELLOW}Nothing to do because `--install` and `--uninstall`",
-            f"was not specified.{RESET_COLOR}",
+            f"{YELLOW}Nothing to do. Use 'install' or 'uninstall' subcommand,"
+            f" or --install/--uninstall flags.{RESET_COLOR}",
+            file=sys.stderr,
         )
         parser.print_help()
+        return 0
+
+    # ---- ``uninstall`` subcommand ------------------------------------
+    if args.command == "uninstall":
+        uninstall_clang_tools(args.version, args.tool, args.directory)
+        return 0
+
+    # ---- ``install`` subcommand --------------------------------------
+    if args.command == "install":
+        target: str = args.target
+        binary: bool = args.binary
+        wheel: bool = args.wheel
+
+        # safety: --binary and --wheel are mutually exclusive
+        if binary and wheel:
+            print(
+                f"{YELLOW}Error: --binary and --wheel are mutually"
+                f" exclusive{RESET_COLOR}",
+                file=sys.stderr,
+            )
+            return 1
+
+        # ---- Case: --wheel (target may be tool name or version) -----
+        if wheel:
+            if _is_version_like(target):
+                # ``clang-tools install 18 --wheel``
+                return _wheel_install(args.tool, target)
+            else:
+                # ``clang-tools install clang-format --wheel``
+                # Install the target as the tool (ignore default --tool)
+                return _wheel_install([target], args.explicit_version)
+
+        # ---- Case: --binary (target must be a version) --------------
+        if binary:
+            if not _is_version_like(target):
+                print(
+                    f"{YELLOW}Error: --binary requires a version number"
+                    f" (got '{target}'){RESET_COLOR}",
+                    file=sys.stderr,
+                )
+                return 1
+            version = Version(target)
+            if version.info != (0, 0, 0):
+                install_clang_tools(
+                    version,
+                    args.tool,
+                    args.directory,
+                    args.overwrite,
+                    args.no_progress_bar,
+                )
+                return 0
+            print(
+                f"{YELLOW}The version specified is not a semantic"
+                f" specification{RESET_COLOR}",
+                file=sys.stderr,
+            )
+            return 1
+
+        # ---- Auto-detect (no --binary or --wheel flag) --------------
+        if _is_version_like(target):
+            version = Version(target)
+            if version.info != (0, 0, 0):
+                # try binary first, fall back to wheel
+                try:
+                    install_clang_tools(
+                        version,
+                        args.tool,
+                        args.directory,
+                        args.overwrite,
+                        args.no_progress_bar,
+                    )
+                    return 0
+                except Exception as exc:
+                    print(
+                        f"{YELLOW}Binary install failed"
+                        f" ({exc}), falling back to"
+                        f" wheel...{RESET_COLOR}",
+                        file=sys.stderr,
+                    )
+                # fallback to wheel
+                return _wheel_install(args.tool, target)
+            else:
+                print(
+                    f"{YELLOW}The version specified is not a semantic"
+                    f" specification{RESET_COLOR}",
+                    file=sys.stderr,
+                )
+                return 1
+        else:
+            # target is a tool name → install via wheel
+            if target not in WHEEL_TOOLS:
+                print(
+                    f"{YELLOW}Unknown target '{target}'. Expected a"
+                    f" version number or one of: "
+                    f"{', '.join(sorted(WHEEL_TOOLS))}{RESET_COLOR}",
+                    file=sys.stderr,
+                )
+                return 1
+            return _wheel_install([target], args.explicit_version)
+
+    return 0  # unreachable
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/clang_tools/util.py
+++ b/clang_tools/util.py
@@ -117,6 +117,10 @@ class Version:
     """
 
     def __init__(self, user_input: str):
+        """Construct a :class:`Version` from *user_input*.
+
+        :param user_input: The version specification as a string.
+        """
         #: The version input in string form
         self.string = user_input
         version_tuple = user_input.split(".")

--- a/clang_tools/wheel.py
+++ b/clang_tools/wheel.py
@@ -20,6 +20,13 @@ def get_parser() -> ArgumentParser:
 
 
 def main() -> int:
+    """Entry point for the wheel-based tool installer.
+
+    Parses CLI args and delegates to
+    :func:`cpp_linter_hooks.util.resolve_install`.
+
+    :returns: exit code (0 on success, 1 on failure).
+    """
     parser = get_parser()
     args = parser.parse_args()
     path = resolve_install(args.tool, args.version)

--- a/docs/api.md
+++ b/docs/api.md
@@ -2,12 +2,12 @@ The `clang-tools` package exposes the following Python modules:
 
 ## `clang_tools.main`
 
-Main entry point for the `clang-tools` CLI.
+Main entry point for the unified `clang-tools` CLI.
 
 [:octicons-code-16: View source](https://github.com/cpp-linter/clang-tools-pip/blob/main/clang_tools/main.py)
 
 Provides the `clang-tools` command-line interface for installing
-and managing clang tool binaries.
+and managing clang tool binaries and Python wheels.
 
 ---
 
@@ -32,9 +32,9 @@ Utility functions shared across the package.
 
 ## `clang_tools.wheel`
 
-Python wheel installation entry point.
+Python wheel installation module (integrated into unified CLI).
 
 [:octicons-code-16: View source](https://github.com/cpp-linter/clang-tools-pip/blob/main/clang_tools/wheel.py)
 
-Provides the `clang-tools-wheel` command-line interface for installing
-clang tool Python wheels.
+Provides wheel-based installation via `cpp-linter-hooks`. Now
+accessible through the unified `clang-tools install --wheel` command.

--- a/docs/gen_cli_docs.py
+++ b/docs/gen_cli_docs.py
@@ -5,6 +5,7 @@ the `cli_args.md` page from argparse.
 """
 
 from io import StringIO
+import argparse
 import mkdocs_gen_files
 from clang_tools.main import get_parser
 
@@ -79,7 +80,7 @@ def _write_cli_doc(parser, prog_name: str) -> str:
     if subparsers_action is not None:
         for name, sub in subparsers_action.choices.items():
             lines.append(f"---\n\n## `{prog_name} {name}`\n")
-            lines.append(f"```text")
+            lines.append("```text")
             sub.prog = f"{prog_name} {name}"
             str_buf = StringIO()
             sub.print_usage(str_buf)

--- a/docs/gen_cli_docs.py
+++ b/docs/gen_cli_docs.py
@@ -1,13 +1,12 @@
 """Generate CLI argument documentation pages for MkDocs.
 
 This script is used as a `gen-files` plugin to auto-generate
-the `cli_args.md` and `wheel_cli_args.md` pages from argparse.
+the `cli_args.md` page from argparse.
 """
 
 from io import StringIO
 import mkdocs_gen_files
 from clang_tools.main import get_parser
-from clang_tools.wheel import get_parser as get_wheel_parser
 
 REQUIRED_VERSIONS = {
     "0.1.0": ["install"],
@@ -72,7 +71,3 @@ def _generate(filename: str, content: str) -> None:
 
 
 _generate("cli_args.md", _write_cli_doc(get_parser(), "clang-tools"))
-_generate(
-    "wheel_cli_args.md",
-    _write_cli_doc(get_wheel_parser(), "clang-tools-wheel"),
-)

--- a/docs/gen_cli_docs.py
+++ b/docs/gen_cli_docs.py
@@ -10,11 +10,12 @@ import mkdocs_gen_files
 from clang_tools.main import get_parser
 
 REQUIRED_VERSIONS = {
-    "0.1.0": ["install"],
+    "0.1.0": ["command", "target", "version"],
     "0.2.0": ["directory"],
     "0.3.0": ["overwrite"],
-    "0.5.0": ["no_progress_bar", "uninstall"],
+    "0.5.0": ["no_progress_bar"],
     "0.11.0": ["tool"],
+    "1.0.0": ["binary", "wheel", "explicit_version"],
 }
 
 

--- a/docs/gen_cli_docs.py
+++ b/docs/gen_cli_docs.py
@@ -17,11 +17,43 @@ REQUIRED_VERSIONS = {
 }
 
 
+def _action_doc(arg) -> str:
+    """Generate markdown for a single argparse action."""
+    aliases = arg.option_strings
+    if not aliases or arg.default == "==SUPPRESS==":
+        return ""
+    if arg.help is None:
+        msg = f"Argument {aliases[0] if aliases else arg.dest} missing help text"
+        raise ValueError(msg)
+
+    lines = [f"### `{', '.join(aliases)}`\n"]
+
+    req_ver = next(
+        (ver for ver, names in REQUIRED_VERSIONS.items() if arg.dest in names),
+        "0.1.0",
+    )
+    badges = [f":material-tag-outline: **v{req_ver}**"]
+
+    if arg.default is not None:
+        default = (
+            " ".join(arg.default) if isinstance(arg.default, list) else arg.default
+        )
+        badges.append(f"Default: `{default}`")
+    if arg.default is False and arg.const is True:
+        badges.append("Accepts no value")
+
+    lines.append(" &nbsp; ".join(badges) + "\n")
+    lines.append(arg.help + "\n")
+    return "\n".join(lines)
+
+
 def _write_cli_doc(parser, prog_name: str) -> str:
     """Generate markdown documentation from an argparse parser."""
     lines = []
     lines.append(f"---\ntitle: {prog_name} CLI\n---\n")
     lines.append(f"# `{prog_name}` CLI Reference\n")
+
+    # Top-level usage
     lines.append("## Usage\n")
     lines.append("```text")
     parser.prog = prog_name
@@ -32,34 +64,36 @@ def _write_cli_doc(parser, prog_name: str) -> str:
     for line in usage.splitlines():
         lines.append(f"    {line[start:]}")
     lines.append("```\n")
-    lines.append("## Options\n")
 
-    args = parser._actions
-    for arg in args:
-        aliases = arg.option_strings
-        if not aliases or arg.default == "==SUPPRESS==":
+    # Top-level options (subcommands placeholder)
+    subparsers_action = None
+    for action in parser._actions:
+        if isinstance(action, argparse._SubParsersAction):
+            subparsers_action = action
             continue
-        if arg.help is None:
-            msg = f"Argument {aliases[0] if aliases else arg.dest} missing help text"
-            raise ValueError(msg)
-        lines.append(f"### `{', '.join(aliases)}`\n")
+        doc = _action_doc(action)
+        if doc:
+            lines.append(doc)
 
-        req_ver = next(
-            (ver for ver, names in REQUIRED_VERSIONS.items() if arg.dest in names),
-            "0.1.0",
-        )
-        badges = [f":material-tag-outline: **v{req_ver}**"]
+    # Subcommand details
+    if subparsers_action is not None:
+        for name, sub in subparsers_action.choices.items():
+            lines.append(f"---\n\n## `{prog_name} {name}`\n")
+            lines.append(f"```text")
+            sub.prog = f"{prog_name} {name}"
+            str_buf = StringIO()
+            sub.print_usage(str_buf)
+            sub_usage = str_buf.getvalue()
+            sub_start = sub_usage.find(sub.prog)
+            lines.append(f"    {sub_usage[sub_start:]}")
+            lines.append("```\n")
 
-        if arg.default is not None:
-            default = (
-                " ".join(arg.default) if isinstance(arg.default, list) else arg.default
-            )
-            badges.append(f"Default: `{default}`")
-        if arg.default is False and arg.const is True:
-            badges.append("Accepts no value")
-
-        lines.append(" &nbsp; ".join(badges) + "\n")
-        lines.append(arg.help + "\n")
+            for action in sub._actions:
+                if not action.option_strings or action.default == "==SUPPRESS==":
+                    continue
+                doc = _action_doc(action)
+                if doc:
+                    lines.append(doc)
 
     return "\n".join(lines)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -108,6 +108,7 @@ Python wheels using the unified `clang-tools` command.
     For general use, it is recommended to install the wheels directly
     using `pip`, `pipx`, `uv`, or similar tools.
 
+    ```bash
     # Install latest clang-format wheel
     clang-tools install clang-format --wheel
     # Install specific version clang-format wheel
@@ -117,6 +118,7 @@ Python wheels using the unified `clang-tools` command.
     clang-tools install clang-tidy --wheel
     # Install specific version clang-tidy wheel
     clang-tools install clang-tidy --wheel --version 21
+    ```
 
 ## Supported Versions
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -69,22 +69,21 @@ Install `clang-tools` from git repo:
 For a list of supported Command Line Interface options, see:
 
 - [`clang-tools` CLI Reference](cli_args.md)
-- [`clang-tools-wheel` CLI Reference](wheel_cli_args.md)
 
 ### Install binaries examples
 
 Use `clang-tools` command to install version 13 binaries:
 
-    clang-tools --install 13
+    clang-tools install 13
 
 Or install to a specified directory:
 
-    clang-tools --install 13 --directory .
+    clang-tools install 13 --directory .
 
 Or install a specified tool, such as `clang-format` and
 `clang-query` version 14:
 
-    clang-tools --install 14 --tool clang-format clang-query
+    clang-tools install 14 --tool clang-format clang-query
 
 If the installed directory is in your path, you can run the installed tools:
 
@@ -101,23 +100,23 @@ If the installed directory is in your path, you can run the installed tools:
 ### Install wheels examples
 
 After installing the `clang-tools` CLI, you can install the
-Python wheels using the `clang-tools-wheel` command.
+Python wheels using the unified `clang-tools` command.
 
 !!! important
-    The `clang-tools-wheel` command is primarily intended for
+    Wheel installation is primarily intended for
     cpp-linter projects to simplify installing clang tools Python wheels.
     For general use, it is recommended to install the wheels directly
     using `pip`, `pipx`, `uv`, or similar tools.
 
     # Install latest clang-format wheel
-    clang-tools-wheel --tool clang-format
+    clang-tools install clang-format --wheel
     # Install specific version clang-format wheel
-    clang-tools-wheel --tool clang-format --version 21
+    clang-tools install clang-format --wheel --version 21
 
     # Install latest clang-tidy wheel
-    clang-tools-wheel --tool clang-tidy
+    clang-tools install clang-tidy --wheel
     # Install specific version clang-tidy wheel
-    clang-tools-wheel --tool clang-tidy --version 21
+    clang-tools install clang-tidy --wheel --version 21
 
 ## Supported Versions
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,7 +11,6 @@ nav:
   - Custom Binary Repository: usage.md
   - CLI Reference:
       - clang-tools: cli_args.md
-      - clang-tools-wheel: wheel_cli_args.md
   - API Reference: api.md
   - "← cpp-linter hub": https://cpp-linter.github.io/
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ tracker = "https://github.com/cpp-linter/clang-tools-pip/issues"
 
 [project.optional-dependencies]
 dev = [
+    "bandit[toml]",
     "coverage[toml]",
     "pre-commit",
     "pytest",
@@ -85,6 +86,9 @@ testpaths = ["tests"]
 [tool.mypy]
 show_error_codes = true
 show_column_numbers = true
+
+[tool.bandit]
+exclude_dirs = ["tests"]
 
 [tool.coverage]
 [tool.coverage.run]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,6 @@ dynamic = ["version"]
 
 [project.scripts]
 clang-tools = "clang_tools.main:main"
-clang-tools-wheel = "clang_tools.wheel:main"
 
 [project.urls]
 source =  "https://github.com/cpp-linter/clang-tools-pip"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,6 @@ tracker = "https://github.com/cpp-linter/clang-tools-pip/issues"
 
 [project.optional-dependencies]
 dev = [
-    "bandit[toml]",
     "coverage[toml]",
     "pre-commit",
     "pytest",
@@ -86,9 +85,6 @@ testpaths = ["tests"]
 [tool.mypy]
 show_error_codes = true
 show_column_numbers = true
-
-[tool.bandit]
-exclude_dirs = ["tests"]
 
 [tool.coverage]
 [tool.coverage.run]

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -101,7 +101,7 @@ def test_path_warning(capsys: pytest.CaptureFixture):
     2. indicates a failure when the requested version is out of the supported range
     """
     try:
-        install_clang_tools(Version("0"), "x", ".", False, False)
+        install_clang_tools(Version("0"), ["x"], ".", False, False)
     except ValueError as exc:
         if install_dir_name(".") not in os.environ.get("PATH", ""):  # pragma: no cover
             # this warning does not happen in an activated venv
@@ -132,7 +132,7 @@ def test_install_clang_tools_download_error(
     """
     monkeypatch.setattr("clang_tools.install.binary_repo", "not-a-valid-url")
     with pytest.raises(OSError, match="Failed to download"):
-        install_clang_tools(Version("12"), "clang-format", str(tmp_path), False, True)
+        install_clang_tools(Version("12"), ["clang-format"], str(tmp_path), False, True)
 
 
 def test_is_installed_found(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
@@ -331,7 +331,7 @@ def test_install_clang_tools_path_not_in_env(
     monkeypatch.setenv("PATH", "/usr/bin:/bin")
 
     with pytest.raises(OSError):
-        install_clang_tools(Version("12"), "clang-format", str(tmp_path), False, True)
+        install_clang_tools(Version("12"), ["clang-format"], str(tmp_path), False, True)
 
     result = capsys.readouterr()
     assert "directory is not in your environment variable PATH" in result.out

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -335,3 +335,38 @@ def test_install_clang_tools_path_not_in_env(
 
     result = capsys.readouterr()
     assert "directory is not in your environment variable PATH" in result.out
+
+
+def test_clang_tools_binary_url_non_macos(monkeypatch: pytest.MonkeyPatch):
+    """Test clang_tools_binary_url with a non-macOS platform string."""
+    monkeypatch.setattr("clang_tools.install.install_os", "linux")
+    monkeypatch.setattr("clang_tools.install.install_arch", "amd64")
+    url = clang_tools_binary_url("clang-format", "12")
+    assert "linux-amd64" in url
+
+
+def test_install_dir_name_linux_default(monkeypatch: pytest.MonkeyPatch):
+    """Test install_dir_name returns ~/.local/bin/ on Linux when no dir given."""
+    monkeypatch.setattr("clang_tools.install.install_os", "linux")
+    result = install_dir_name("")
+    assert result == os.path.expanduser("~/.local/bin/")
+
+
+def test_create_sym_link_nonexistent_dir(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    """Test create_sym_link creates the install directory if it doesn't exist."""
+    monkeypatch.chdir(str(tmp_path))
+    tool_name, version = "clang-tool", "1"
+    # Create the target binary in tmp_path
+    target = tmp_path / f"{tool_name}-{version}{suffix}"
+    target.write_bytes(b"some binary data")
+
+    # Use a nested subdir that does not exist yet
+    new_dir = tmp_path / "new_install_dir"
+    assert not new_dir.exists()
+
+    assert create_sym_link(tool_name, version, str(new_dir), False, target=target)
+    assert new_dir.exists()
+    link = new_dir / f"{tool_name}{suffix}"
+    assert link.is_symlink()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,56 +1,160 @@
-"""Tests that relate to the main.py module."""
+"""Tests that relate to the unified main.py CLI."""
 
 from typing import Optional, List
 from argparse import ArgumentParser
 import sys
 import pytest
 from clang_tools import suffix
-from clang_tools.main import get_parser, main
+from clang_tools.main import get_parser, main, _is_version_like
 
 
 class Args:
-    """A pseudo namespace for testing argparse.
-    These class attributes are set to the CLI args default values."""
+    """Pseudo namespace for testing argparse defaults (legacy top-level flags)."""
 
+    command: Optional[str] = None
     directory: str = ""
-    install: Optional[str] = None
+    _legacy_install: Optional[str] = None
+    overlay: bool = False
     overwrite: bool = False
     no_progress_bar: bool = False
-    uninstall: Optional[str] = None
+    _legacy_uninstall: Optional[str] = None
     tool: List[str] = ["clang-format", "clang-tidy"]
 
 
+# ---------------------------------------------------------------------------
+#  _is_version_like helper
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "target,expected",
+    [
+        ("18", True),
+        ("18.1", True),
+        ("18.1.0", True),
+        ("clang-format", False),
+        ("clang-tidy", False),
+        ("abc", False),
+    ],
+)
+def test_is_version_like(target: str, expected: bool):
+    assert _is_version_like(target) is expected
+
+
+# ---------------------------------------------------------------------------
+#  Parser – new subcommands
+# ---------------------------------------------------------------------------
+
 @pytest.fixture
 def parser() -> ArgumentParser:
-    """get the arg parser for the tests in this module."""
     return get_parser()
 
 
-@pytest.mark.parametrize("arg_name", ["install", "directory", "uninstall"])
+def test_install_subcommand_defaults(parser: ArgumentParser):
+    """Default values for the ``install`` subcommand."""
+    args = parser.parse_args(["install", "18"])
+    assert args.command == "install"
+    assert args.target == "18"
+    assert args.binary is False
+    assert args.wheel is False
+    assert args.tool == ["clang-format", "clang-tidy"]
+    assert args.directory == ""
+    assert args.overwrite is False
+    assert args.no_progress_bar is False
+
+
+def test_install_subcommand_binary(parser: ArgumentParser):
+    args = parser.parse_args(["install", "18", "--binary"])
+    assert args.binary is True
+    assert args.wheel is False
+
+
+def test_install_subcommand_wheel(parser: ArgumentParser):
+    args = parser.parse_args(["install", "clang-format", "--wheel"])
+    assert args.wheel is True
+    assert args.binary is False
+
+
+def test_install_subcommand_wheel_with_version(parser: ArgumentParser):
+    args = parser.parse_args(
+        ["install", "clang-format", "--wheel", "--version", "15.0.7"]
+    )
+    assert args.wheel is True
+    assert args.target == "clang-format"
+    assert args.explicit_version == "15.0.7"
+
+
+def test_install_subcommand_custom_tools(parser: ArgumentParser):
+    args = parser.parse_args(["install", "18", "-t", "clang-tidy"])
+    assert args.tool == ["clang-tidy"]
+
+
+def test_install_subcommand_directory(parser: ArgumentParser):
+    args = parser.parse_args(["install", "18", "-d", "/custom/path"])
+    assert args.directory == "/custom/path"
+
+
+def test_install_subcommand_flags(parser: ArgumentParser):
+    args = parser.parse_args(["install", "18", "--overwrite", "--no-progress-bar"])
+    assert args.overwrite is True
+    assert args.no_progress_bar is True
+
+
+def test_uninstall_subcommand(parser: ArgumentParser):
+    args = parser.parse_args(["uninstall", "12", "-t", "clang-format"])
+    assert args.command == "uninstall"
+    assert args.version == "12"
+    assert args.tool == ["clang-format"]
+
+
+def test_uninstall_subcommand_defaults(parser: ArgumentParser):
+    args = parser.parse_args(["uninstall", "12"])
+    assert args.tool == ["clang-format", "clang-tidy"]
+    assert args.directory == ""
+
+
+# ---------------------------------------------------------------------------
+#  Backward-compat legacy flags (still work)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("arg_name", ["install", "uninstall"])
 @pytest.mark.parametrize("arg_value", [str(v) for v in range(7, 17)])
-def test_arg_parser(arg_name: str, arg_value: str, parser: ArgumentParser):
-    """Test CLI arg parsing using a set of fake args."""
+def test_legacy_arg_parser(arg_name: str, arg_value: str, parser: ArgumentParser):
+    """Test legacy --install/--uninstall flags still parse."""
     args = parser.parse_args([f"--{arg_name}={arg_value}"])
-    assert getattr(args, arg_name) == arg_value
+    assert getattr(args, f"_legacy_{arg_name}") == arg_value
 
 
 @pytest.mark.parametrize("switch_name", ["overwrite", "no-progress-bar"])
-def test_cli_switch(switch_name: str, parser: ArgumentParser):
-    """Test the CLI switches/flags"""
+def test_legacy_cli_switch(switch_name: str, parser: ArgumentParser):
+    """Test legacy switches/flags."""
     args = parser.parse_args([f"--{switch_name}"])
     assert getattr(args, switch_name.replace("-", "_"))
 
 
-def test_default_args(parser: ArgumentParser):
-    """Test the default values of CLI args"""
+def test_legacy_default_args(parser: ArgumentParser):
+    """Test legacy default values."""
     args = parser.parse_args([])
     for name, value in args.__dict__.items():
         assert getattr(Args, name) == value
 
 
-def test_main_uninstall(monkeypatch: pytest.MonkeyPatch, tmp_path, capsys):
-    """Test main() with --uninstall flag."""
-    # Create a dummy bin to uninstall
+# ---------------------------------------------------------------------------
+#  Integration / functional tests
+# ---------------------------------------------------------------------------
+
+def test_main_no_args(monkeypatch: pytest.MonkeyPatch, capsys):
+    """``clang-tools`` with no args prints help."""
+    monkeypatch.setattr(sys, "argv", ["clang-tools"])
+    exit_code = main()
+    result = capsys.readouterr()
+    assert "Nothing to do" in result.err
+    assert exit_code == 0
+
+
+def test_main_legacy_uninstall(
+    monkeypatch: pytest.MonkeyPatch, tmp_path, capsys
+):
+    """Legacy ``--uninstall`` flag still works."""
     tool_name = "clang-format"
     version = "12"
     install_dir = str(tmp_path)
@@ -70,14 +174,14 @@ def test_main_uninstall(monkeypatch: pytest.MonkeyPatch, tmp_path, capsys):
             install_dir,
         ],
     )
-    main()
-    # Verifies uninstall path was entered (printed the uninstall message)
+    exit_code = main()
     result = capsys.readouterr()
     assert "Uninstalling" in result.out
+    assert exit_code == 0
 
 
-def test_main_install(monkeypatch: pytest.MonkeyPatch, tmp_path):
-    """Test main() with --install flag."""
+def test_main_legacy_install(monkeypatch: pytest.MonkeyPatch, tmp_path):
+    """Legacy ``--install`` flag still works."""
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(
         sys,
@@ -93,14 +197,16 @@ def test_main_install(monkeypatch: pytest.MonkeyPatch, tmp_path):
             "--no-progress-bar",
         ],
     )
-    main()
-    # Binary should be installed
+    exit_code = main()
+    assert exit_code == 0
     bin_path = tmp_path / f"clang-format-12{suffix}"
     assert bin_path.exists()
 
 
-def test_main_install_invalid_version(monkeypatch: pytest.MonkeyPatch, capsys):
-    """Test main() with --install using a non-semver version."""
+def test_main_legacy_install_invalid_version(
+    monkeypatch: pytest.MonkeyPatch, capsys
+):
+    """Legacy ``--install`` with invalid version shows error."""
     monkeypatch.setattr(
         sys,
         "argv",
@@ -112,14 +218,355 @@ def test_main_install_invalid_version(monkeypatch: pytest.MonkeyPatch, capsys):
             "clang-format",
         ],
     )
-    main()
+    exit_code = main()
     result = capsys.readouterr()
-    assert "not a semantic" in result.out
+    assert "not a semantic" in result.err
+    assert exit_code == 1
 
 
-def test_main_no_args(monkeypatch: pytest.MonkeyPatch, capsys):
-    """Test main() with no arguments shows help."""
-    monkeypatch.setattr(sys, "argv", ["clang-tools"])
-    main()
+# ---- New ``install`` subcommand ---------------------------------------
+
+
+def test_main_install_binary(monkeypatch: pytest.MonkeyPatch, tmp_path):
+    """``clang-tools install 12 --binary`` installs binary."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "clang-tools",
+            "install",
+            "12",
+            "--binary",
+            "--tool",
+            "clang-format",
+            "--directory",
+            str(tmp_path),
+            "--no-progress-bar",
+        ],
+    )
+    exit_code = main()
+    assert exit_code == 0
+    bin_path = tmp_path / f"clang-format-12{suffix}"
+    assert bin_path.exists()
+
+
+def test_main_install_binary_requires_version(
+    monkeypatch: pytest.MonkeyPatch, capsys
+):
+    """``--binary`` with a non-version target is an error."""
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "clang-tools",
+            "install",
+            "clang-format",
+            "--binary",
+        ],
+    )
+    exit_code = main()
     result = capsys.readouterr()
-    assert "Nothing to do" in result.out
+    assert "requires a version number" in result.err
+    assert exit_code == 1
+
+
+def test_main_install_binary_invalid_version(
+    monkeypatch: pytest.MonkeyPatch, capsys
+):
+    """``--binary`` with a non-version target shows 'requires a version number'."""
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "clang-tools",
+            "install",
+            "not-a-version",
+            "--binary",
+        ],
+    )
+    exit_code = main()
+    result = capsys.readouterr()
+    assert "requires a version number" in result.err
+    assert exit_code == 1
+
+
+def test_main_install_binary_and_wheel_mutex(
+    monkeypatch: pytest.MonkeyPatch, capsys
+):
+    """``--binary`` and ``--wheel`` together is an error."""
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "clang-tools",
+            "install",
+            "18",
+            "--binary",
+            "--wheel",
+        ],
+    )
+    exit_code = main()
+    result = capsys.readouterr()
+    assert "mutually exclusive" in result.err
+    assert exit_code == 1
+
+
+def test_main_install_wheel_success(monkeypatch: pytest.MonkeyPatch, capsys):
+    """``--wheel`` with a tool name succeeds via mocked _wheel_install."""
+    monkeypatch.setattr(
+        "clang_tools.main._wheel_install",
+        lambda tools, ver: 0,
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["clang-tools", "install", "clang-format", "--wheel"],
+    )
+    exit_code = main()
+    result = capsys.readouterr()
+    assert exit_code == 0
+    assert result.err == ""
+
+
+def test_main_install_wheel_failure(monkeypatch: pytest.MonkeyPatch, capsys):
+    """``--wheel`` with a failing _wheel_install returns 1."""
+    monkeypatch.setattr(
+        "clang_tools.main._wheel_install", lambda tools, ver: 1
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["clang-tools", "install", "clang-format", "--wheel"],
+    )
+    exit_code = main()
+    assert exit_code == 1
+
+
+def test_main_install_wheel_version_arg(monkeypatch: pytest.MonkeyPatch, capsys):
+    """``--wheel`` with ``--version`` passes version to _wheel_install."""
+    tracked_version = []
+
+    def mock_wheel(tools, version):
+        tracked_version.append((tools, version))
+        return 0
+
+    monkeypatch.setattr("clang_tools.main._wheel_install", mock_wheel)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["clang-tools", "install", "clang-format", "--wheel", "--version", "15.0.7"],
+    )
+    exit_code = main()
+    assert exit_code == 0
+    assert tracked_version == [(["clang-format"], "15.0.7")]
+
+
+def test_main_install_wheel_with_version_as_target(
+    monkeypatch: pytest.MonkeyPatch, capsys
+):
+    """``clang-tools install 18 --wheel`` uses version as target, tool from -t."""
+    tracked: list = []
+
+    def mock_wheel(tools, version):
+        tracked.append((tools, version))
+        return 0
+
+    monkeypatch.setattr("clang_tools.main._wheel_install", mock_wheel)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "clang-tools",
+            "install",
+            "18",
+            "--wheel",
+            "-t",
+            "clang-tidy",
+        ],
+    )
+    exit_code = main()
+    assert exit_code == 0
+    assert tracked == [(["clang-tidy"], "18")]
+
+
+def test_main_install_auto_detect_binary(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+):
+    """Auto-detect installs binary for version in supported range."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "clang-tools",
+            "install",
+            "12",
+            "--tool",
+            "clang-format",
+            "--directory",
+            str(tmp_path),
+            "--no-progress-bar",
+        ],
+    )
+    exit_code = main()
+    assert exit_code == 0
+    bin_path = tmp_path / f"clang-format-12{suffix}"
+    assert bin_path.exists()
+
+
+def test_main_install_auto_detect_fallback(
+    monkeypatch: pytest.MonkeyPatch, tmp_path, capsys
+):
+    """Auto-detect falls back to wheel when binary fails."""
+    # Cause binary install to fail
+    monkeypatch.setattr("clang_tools.install.binary_repo", "not-a-valid-url")
+    monkeypatch.setattr(
+        "clang_tools.main._wheel_install",
+        lambda tools, ver: 0,
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "clang-tools",
+            "install",
+            "12",
+            "--tool",
+            "clang-format",
+            "--no-progress-bar",
+        ],
+    )
+    exit_code = main()
+    result = capsys.readouterr()
+    assert exit_code == 0
+    assert "falling back to wheel" in result.err
+
+
+def test_main_install_auto_detect_non_version(
+    monkeypatch: pytest.MonkeyPatch, capsys
+):
+    """Auto-detect treats non-version target as tool name (wheel install)."""
+    tracked_install: list = []
+
+    def mock_wheel(tools, version):
+        tracked_install.append((tools, version))
+        return 0
+
+    monkeypatch.setattr("clang_tools.main._wheel_install", mock_wheel)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["clang-tools", "install", "clang-tidy"],
+    )
+    exit_code = main()
+    result = capsys.readouterr()
+    assert exit_code == 0
+    assert tracked_install == [(["clang-tidy"], None)]
+
+
+def test_main_install_auto_detect_out_of_range_version(
+    monkeypatch: pytest.MonkeyPatch, capsys
+):
+    """Auto-detect goes straight to wheel for out-of-range versions."""
+    # Version 99 is outside MIN_VERSION..MAX_VERSION, install_clang_tools
+    # raises ValueError → caught → fallback to wheel
+    monkeypatch.setattr(
+        "clang_tools.main._wheel_install",
+        lambda tools, ver: 0,
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "clang-tools",
+            "install",
+            "99",
+            "--tool",
+            "clang-format",
+        ],
+    )
+    exit_code = main()
+    result = capsys.readouterr()
+    assert exit_code == 0
+    assert "falling back to wheel" in result.err
+
+
+def test_main_install_auto_detect_invalid_version(
+    monkeypatch: pytest.MonkeyPatch, capsys
+):
+    """Auto-detect with a non-version, non-tool target shows error."""
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["clang-tools", "install", "abc.def"],
+    )
+    exit_code = main()
+    result = capsys.readouterr()
+    assert "Unknown target" in result.err
+    assert exit_code == 1
+
+
+# ---- New ``uninstall`` subcommand -------------------------------------
+
+
+def test_main_uninstall_subcommand(
+    monkeypatch: pytest.MonkeyPatch, tmp_path, capsys
+):
+    """``clang-tools uninstall 12`` removes installed tools."""
+    tool_name = "clang-format"
+    version = "12"
+    install_dir = str(tmp_path)
+    dummy_bin = tmp_path / f"{tool_name}-{version}{suffix}"
+    dummy_bin.write_bytes(b"dummy")
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "clang-tools",
+            "uninstall",
+            version,
+            "--tool",
+            tool_name,
+            "--directory",
+            install_dir,
+        ],
+    )
+    exit_code = main()
+    result = capsys.readouterr()
+    assert exit_code == 0
+    assert "Uninstalling" in result.out
+
+
+def test_main_legacy_install_and_uninstall(
+    monkeypatch: pytest.MonkeyPatch, tmp_path, capsys
+):
+    """Legacy combined ``--install`` and ``--uninstall`` flags."""
+    monkeypatch.chdir(tmp_path)
+    version = "12"
+    tool_name = "clang-format"
+    # pre-create dummy to uninstall
+    dummy_bin = tmp_path / f"{tool_name}-{version}{suffix}"
+    dummy_bin.write_bytes(b"dummy")
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "clang-tools",
+            "--uninstall",
+            version,
+            "--install",
+            version,
+            "--tool",
+            tool_name,
+            "--directory",
+            str(tmp_path),
+            "--no-progress-bar",
+        ],
+    )
+    exit_code = main()
+    result = capsys.readouterr()
+    assert exit_code == 0
+    assert "Uninstalling" in result.out

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -375,6 +375,39 @@ def test_main_install_auto_detect_invalid_version(
 # ---- ``uninstall`` subcommand -----------------------------------------
 
 
+def test_wheel_install_success(monkeypatch: pytest.MonkeyPatch, capsys):
+    """Test _wheel_install directly with a mocked resolve_install (success)."""
+    from clang_tools.main import _wheel_install
+
+    monkeypatch.setattr(
+        "cpp_linter_hooks.util.resolve_install", lambda t, v: f"/fake/{t}"
+    )
+    assert _wheel_install(["clang-format"], "18") == 0
+    assert "installed at:" in capsys.readouterr().out
+
+
+def test_wheel_install_failure(monkeypatch: pytest.MonkeyPatch, capsys):
+    """Test _wheel_install directly with a failing resolve_install."""
+    from clang_tools.main import _wheel_install
+
+    monkeypatch.setattr("cpp_linter_hooks.util.resolve_install", lambda t, v: None)
+    assert _wheel_install(["clang-tidy"], "21") == 1
+    assert "Failed to install" in capsys.readouterr().err
+
+
+def test_main_install_binary_bad_semver(monkeypatch: pytest.MonkeyPatch, capsys):
+    """``--binary`` with a version-like but zeroed-out version (e.g. 0.0.0)."""
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["clang-tools", "install", "0.0.0", "--binary"],
+    )
+    exit_code = main()
+    result = capsys.readouterr()
+    assert exit_code == 1
+    assert "not a semantic" in result.err
+
+
 def test_main_uninstall_subcommand(monkeypatch: pytest.MonkeyPatch, tmp_path, capsys):
     """``clang-tools uninstall 12`` removes installed tools."""
     tool_name = "clang-format"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -400,3 +400,4 @@ def test_main_uninstall_subcommand(monkeypatch: pytest.MonkeyPatch, tmp_path, ca
     result = capsys.readouterr()
     assert exit_code == 0
     assert "Uninstalling" in result.out
+    assert not dummy_bin.exists()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,24 +1,10 @@
 """Tests that relate to the unified main.py CLI."""
 
-from typing import Optional, List
-from argparse import ArgumentParser
 import sys
+from argparse import ArgumentParser
 import pytest
 from clang_tools import suffix
 from clang_tools.main import get_parser, main, _is_version_like
-
-
-class Args:
-    """Pseudo namespace for testing argparse defaults (legacy top-level flags)."""
-
-    command: Optional[str] = None
-    directory: str = ""
-    _legacy_install: Optional[str] = None
-    overlay: bool = False
-    overwrite: bool = False
-    no_progress_bar: bool = False
-    _legacy_uninstall: Optional[str] = None
-    tool: List[str] = ["clang-format", "clang-tidy"]
 
 
 # ---------------------------------------------------------------------------
@@ -41,7 +27,7 @@ def test_is_version_like(target: str, expected: bool):
 
 
 # ---------------------------------------------------------------------------
-#  Parser – new subcommands
+#  Parser – install subcommand
 # ---------------------------------------------------------------------------
 
 @pytest.fixture
@@ -113,32 +99,6 @@ def test_uninstall_subcommand_defaults(parser: ArgumentParser):
 
 
 # ---------------------------------------------------------------------------
-#  Backward-compat legacy flags (still work)
-# ---------------------------------------------------------------------------
-
-@pytest.mark.parametrize("arg_name", ["install", "uninstall"])
-@pytest.mark.parametrize("arg_value", [str(v) for v in range(7, 17)])
-def test_legacy_arg_parser(arg_name: str, arg_value: str, parser: ArgumentParser):
-    """Test legacy --install/--uninstall flags still parse."""
-    args = parser.parse_args([f"--{arg_name}={arg_value}"])
-    assert getattr(args, f"_legacy_{arg_name}") == arg_value
-
-
-@pytest.mark.parametrize("switch_name", ["overwrite", "no-progress-bar"])
-def test_legacy_cli_switch(switch_name: str, parser: ArgumentParser):
-    """Test legacy switches/flags."""
-    args = parser.parse_args([f"--{switch_name}"])
-    assert getattr(args, switch_name.replace("-", "_"))
-
-
-def test_legacy_default_args(parser: ArgumentParser):
-    """Test legacy default values."""
-    args = parser.parse_args([])
-    for name, value in args.__dict__.items():
-        assert getattr(Args, name) == value
-
-
-# ---------------------------------------------------------------------------
 #  Integration / functional tests
 # ---------------------------------------------------------------------------
 
@@ -151,80 +111,7 @@ def test_main_no_args(monkeypatch: pytest.MonkeyPatch, capsys):
     assert exit_code == 0
 
 
-def test_main_legacy_uninstall(
-    monkeypatch: pytest.MonkeyPatch, tmp_path, capsys
-):
-    """Legacy ``--uninstall`` flag still works."""
-    tool_name = "clang-format"
-    version = "12"
-    install_dir = str(tmp_path)
-    dummy_bin = tmp_path / f"{tool_name}-{version}{suffix}"
-    dummy_bin.write_bytes(b"dummy")
-
-    monkeypatch.setattr(
-        sys,
-        "argv",
-        [
-            "clang-tools",
-            "--uninstall",
-            version,
-            "--tool",
-            tool_name,
-            "--directory",
-            install_dir,
-        ],
-    )
-    exit_code = main()
-    result = capsys.readouterr()
-    assert "Uninstalling" in result.out
-    assert exit_code == 0
-
-
-def test_main_legacy_install(monkeypatch: pytest.MonkeyPatch, tmp_path):
-    """Legacy ``--install`` flag still works."""
-    monkeypatch.chdir(tmp_path)
-    monkeypatch.setattr(
-        sys,
-        "argv",
-        [
-            "clang-tools",
-            "--install",
-            "12",
-            "--tool",
-            "clang-format",
-            "--directory",
-            str(tmp_path),
-            "--no-progress-bar",
-        ],
-    )
-    exit_code = main()
-    assert exit_code == 0
-    bin_path = tmp_path / f"clang-format-12{suffix}"
-    assert bin_path.exists()
-
-
-def test_main_legacy_install_invalid_version(
-    monkeypatch: pytest.MonkeyPatch, capsys
-):
-    """Legacy ``--install`` with invalid version shows error."""
-    monkeypatch.setattr(
-        sys,
-        "argv",
-        [
-            "clang-tools",
-            "--install",
-            "not-a-version",
-            "--tool",
-            "clang-format",
-        ],
-    )
-    exit_code = main()
-    result = capsys.readouterr()
-    assert "not a semantic" in result.err
-    assert exit_code == 1
-
-
-# ---- New ``install`` subcommand ---------------------------------------
+# ---- ``install`` subcommand -------------------------------------------
 
 
 def test_main_install_binary(monkeypatch: pytest.MonkeyPatch, tmp_path):
@@ -258,12 +145,7 @@ def test_main_install_binary_requires_version(
     monkeypatch.setattr(
         sys,
         "argv",
-        [
-            "clang-tools",
-            "install",
-            "clang-format",
-            "--binary",
-        ],
+        ["clang-tools", "install", "clang-format", "--binary"],
     )
     exit_code = main()
     result = capsys.readouterr()
@@ -274,16 +156,11 @@ def test_main_install_binary_requires_version(
 def test_main_install_binary_invalid_version(
     monkeypatch: pytest.MonkeyPatch, capsys
 ):
-    """``--binary`` with a non-version target shows 'requires a version number'."""
+    """``--binary`` with a non-version target shows error."""
     monkeypatch.setattr(
         sys,
         "argv",
-        [
-            "clang-tools",
-            "install",
-            "not-a-version",
-            "--binary",
-        ],
+        ["clang-tools", "install", "not-a-version", "--binary"],
     )
     exit_code = main()
     result = capsys.readouterr()
@@ -298,13 +175,7 @@ def test_main_install_binary_and_wheel_mutex(
     monkeypatch.setattr(
         sys,
         "argv",
-        [
-            "clang-tools",
-            "install",
-            "18",
-            "--binary",
-            "--wheel",
-        ],
+        ["clang-tools", "install", "18", "--binary", "--wheel"],
     )
     exit_code = main()
     result = capsys.readouterr()
@@ -355,7 +226,14 @@ def test_main_install_wheel_version_arg(monkeypatch: pytest.MonkeyPatch, capsys)
     monkeypatch.setattr(
         sys,
         "argv",
-        ["clang-tools", "install", "clang-format", "--wheel", "--version", "15.0.7"],
+        [
+            "clang-tools",
+            "install",
+            "clang-format",
+            "--wheel",
+            "--version",
+            "15.0.7",
+        ],
     )
     exit_code = main()
     assert exit_code == 0
@@ -376,14 +254,7 @@ def test_main_install_wheel_with_version_as_target(
     monkeypatch.setattr(
         sys,
         "argv",
-        [
-            "clang-tools",
-            "install",
-            "18",
-            "--wheel",
-            "-t",
-            "clang-tidy",
-        ],
+        ["clang-tools", "install", "18", "--wheel", "-t", "clang-tidy"],
     )
     exit_code = main()
     assert exit_code == 0
@@ -419,7 +290,6 @@ def test_main_install_auto_detect_fallback(
     monkeypatch: pytest.MonkeyPatch, tmp_path, capsys
 ):
     """Auto-detect falls back to wheel when binary fails."""
-    # Cause binary install to fail
     monkeypatch.setattr("clang_tools.install.binary_repo", "not-a-valid-url")
     monkeypatch.setattr(
         "clang_tools.main._wheel_install",
@@ -460,7 +330,6 @@ def test_main_install_auto_detect_non_version(
         ["clang-tools", "install", "clang-tidy"],
     )
     exit_code = main()
-    result = capsys.readouterr()
     assert exit_code == 0
     assert tracked_install == [(["clang-tidy"], None)]
 
@@ -468,9 +337,7 @@ def test_main_install_auto_detect_non_version(
 def test_main_install_auto_detect_out_of_range_version(
     monkeypatch: pytest.MonkeyPatch, capsys
 ):
-    """Auto-detect goes straight to wheel for out-of-range versions."""
-    # Version 99 is outside MIN_VERSION..MAX_VERSION, install_clang_tools
-    # raises ValueError → caught → fallback to wheel
+    """Auto-detect falls back to wheel for out-of-range versions."""
     monkeypatch.setattr(
         "clang_tools.main._wheel_install",
         lambda tools, ver: 0,
@@ -478,13 +345,7 @@ def test_main_install_auto_detect_out_of_range_version(
     monkeypatch.setattr(
         sys,
         "argv",
-        [
-            "clang-tools",
-            "install",
-            "99",
-            "--tool",
-            "clang-format",
-        ],
+        ["clang-tools", "install", "99", "--tool", "clang-format"],
     )
     exit_code = main()
     result = capsys.readouterr()
@@ -507,7 +368,7 @@ def test_main_install_auto_detect_invalid_version(
     assert exit_code == 1
 
 
-# ---- New ``uninstall`` subcommand -------------------------------------
+# ---- ``uninstall`` subcommand -----------------------------------------
 
 
 def test_main_uninstall_subcommand(
@@ -531,39 +392,6 @@ def test_main_uninstall_subcommand(
             tool_name,
             "--directory",
             install_dir,
-        ],
-    )
-    exit_code = main()
-    result = capsys.readouterr()
-    assert exit_code == 0
-    assert "Uninstalling" in result.out
-
-
-def test_main_legacy_install_and_uninstall(
-    monkeypatch: pytest.MonkeyPatch, tmp_path, capsys
-):
-    """Legacy combined ``--install`` and ``--uninstall`` flags."""
-    monkeypatch.chdir(tmp_path)
-    version = "12"
-    tool_name = "clang-format"
-    # pre-create dummy to uninstall
-    dummy_bin = tmp_path / f"{tool_name}-{version}{suffix}"
-    dummy_bin.write_bytes(b"dummy")
-
-    monkeypatch.setattr(
-        sys,
-        "argv",
-        [
-            "clang-tools",
-            "--uninstall",
-            version,
-            "--install",
-            version,
-            "--tool",
-            tool_name,
-            "--directory",
-            str(tmp_path),
-            "--no-progress-bar",
         ],
     )
     exit_code = main()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -434,3 +434,68 @@ def test_main_uninstall_subcommand(monkeypatch: pytest.MonkeyPatch, tmp_path, ca
     assert exit_code == 0
     assert "Uninstalling" in result.out
     assert not dummy_bin.exists()
+
+
+# ---------------------------------------------------------------------------
+#  Additional _wheel_install coverage (version=None, multi-tool mix)
+# ---------------------------------------------------------------------------
+
+
+def test_wheel_install_latest_success(monkeypatch: pytest.MonkeyPatch, capsys):
+    """Test _wheel_install with version=None ("latest version" path, success)."""
+    from clang_tools.main import _wheel_install
+
+    monkeypatch.setattr(
+        "cpp_linter_hooks.util.resolve_install", lambda t, v: f"/fake/{t}"
+    )
+    assert _wheel_install(["clang-format"], None) == 0
+    result = capsys.readouterr()
+    assert "latest version" in result.out
+    assert "installed at:" in result.out
+
+
+def test_wheel_install_latest_failure(monkeypatch: pytest.MonkeyPatch, capsys):
+    """Test _wheel_install with version=None ("latest version" path, failure)."""
+    from clang_tools.main import _wheel_install
+
+    monkeypatch.setattr("cpp_linter_hooks.util.resolve_install", lambda t, v: None)
+    assert _wheel_install(["clang-tidy"], None) == 1
+    result = capsys.readouterr()
+    assert "latest version" in result.err
+    assert "Failed to install" in result.err
+
+
+def test_wheel_install_multiple_tools_mixed(monkeypatch: pytest.MonkeyPatch, capsys):
+    """Test _wheel_install with multiple tools where one fails and one succeeds."""
+    from clang_tools.main import _wheel_install
+
+    def mock_resolve(tool, version):
+        if tool == "clang-tidy":
+            return None  # fails
+        return f"/fake/{tool}"  # succeeds
+
+    monkeypatch.setattr("cpp_linter_hooks.util.resolve_install", mock_resolve)
+    assert _wheel_install(["clang-format", "clang-tidy"], "18") == 1
+    result = capsys.readouterr()
+    assert "installed at: /fake/clang-format" in result.out
+    assert "Failed to install clang-tidy" in result.err
+
+
+# ---------------------------------------------------------------------------
+#  Additional _handle_auto_detect coverage (bad semver path)
+# ---------------------------------------------------------------------------
+
+
+def test_main_install_auto_detect_bad_semver(
+    monkeypatch: pytest.MonkeyPatch, capsys
+):
+    """Auto-detect with a version that parses to (0,0,0) shows error."""
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["clang-tools", "install", "0.0.0"],
+    )
+    exit_code = main()
+    result = capsys.readouterr()
+    assert exit_code == 1
+    assert "not a semantic" in result.err

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -486,9 +486,7 @@ def test_wheel_install_multiple_tools_mixed(monkeypatch: pytest.MonkeyPatch, cap
 # ---------------------------------------------------------------------------
 
 
-def test_main_install_auto_detect_bad_semver(
-    monkeypatch: pytest.MonkeyPatch, capsys
-):
+def test_main_install_auto_detect_bad_semver(monkeypatch: pytest.MonkeyPatch, capsys):
     """Auto-detect with a version that parses to (0,0,0) shows error."""
     monkeypatch.setattr(
         sys,

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -11,6 +11,7 @@ from clang_tools.main import get_parser, main, _is_version_like
 #  _is_version_like helper
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.parametrize(
     "target,expected",
     [
@@ -29,6 +30,7 @@ def test_is_version_like(target: str, expected: bool):
 # ---------------------------------------------------------------------------
 #  Parser – install subcommand
 # ---------------------------------------------------------------------------
+
 
 @pytest.fixture
 def parser() -> ArgumentParser:
@@ -102,6 +104,7 @@ def test_uninstall_subcommand_defaults(parser: ArgumentParser):
 #  Integration / functional tests
 # ---------------------------------------------------------------------------
 
+
 def test_main_no_args(monkeypatch: pytest.MonkeyPatch, capsys):
     """``clang-tools`` with no args prints help."""
     monkeypatch.setattr(sys, "argv", ["clang-tools"])
@@ -138,9 +141,7 @@ def test_main_install_binary(monkeypatch: pytest.MonkeyPatch, tmp_path):
     assert bin_path.exists()
 
 
-def test_main_install_binary_requires_version(
-    monkeypatch: pytest.MonkeyPatch, capsys
-):
+def test_main_install_binary_requires_version(monkeypatch: pytest.MonkeyPatch, capsys):
     """``--binary`` with a non-version target is an error."""
     monkeypatch.setattr(
         sys,
@@ -153,9 +154,7 @@ def test_main_install_binary_requires_version(
     assert exit_code == 1
 
 
-def test_main_install_binary_invalid_version(
-    monkeypatch: pytest.MonkeyPatch, capsys
-):
+def test_main_install_binary_invalid_version(monkeypatch: pytest.MonkeyPatch, capsys):
     """``--binary`` with a non-version target shows error."""
     monkeypatch.setattr(
         sys,
@@ -168,9 +167,7 @@ def test_main_install_binary_invalid_version(
     assert exit_code == 1
 
 
-def test_main_install_binary_and_wheel_mutex(
-    monkeypatch: pytest.MonkeyPatch, capsys
-):
+def test_main_install_binary_and_wheel_mutex(monkeypatch: pytest.MonkeyPatch, capsys):
     """``--binary`` and ``--wheel`` together is an error."""
     monkeypatch.setattr(
         sys,
@@ -200,9 +197,7 @@ def test_main_install_wheel_success(monkeypatch: pytest.MonkeyPatch, capsys):
     assert result.err == ""
 
 
-def test_main_install_wheel_unsupported_tool(
-    monkeypatch: pytest.MonkeyPatch, capsys
-):
+def test_main_install_wheel_unsupported_tool(monkeypatch: pytest.MonkeyPatch, capsys):
     """``--wheel`` with a binary-only tool name shows error."""
     monkeypatch.setattr(
         sys,
@@ -217,9 +212,7 @@ def test_main_install_wheel_unsupported_tool(
 
 def test_main_install_wheel_failure(monkeypatch: pytest.MonkeyPatch, capsys):
     """``--wheel`` with a failing _wheel_install returns 1."""
-    monkeypatch.setattr(
-        "clang_tools.main._wheel_install", lambda tools, ver: 1
-    )
+    monkeypatch.setattr("clang_tools.main._wheel_install", lambda tools, ver: 1)
     monkeypatch.setattr(
         sys,
         "argv",
@@ -276,9 +269,7 @@ def test_main_install_wheel_with_version_as_target(
     assert tracked == [(["clang-tidy"], "18")]
 
 
-def test_main_install_auto_detect_binary(
-    monkeypatch: pytest.MonkeyPatch, tmp_path
-):
+def test_main_install_auto_detect_binary(monkeypatch: pytest.MonkeyPatch, tmp_path):
     """Auto-detect installs binary for version in supported range."""
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(
@@ -328,9 +319,7 @@ def test_main_install_auto_detect_fallback(
     assert "falling back to wheel" in result.err
 
 
-def test_main_install_auto_detect_non_version(
-    monkeypatch: pytest.MonkeyPatch, capsys
-):
+def test_main_install_auto_detect_non_version(monkeypatch: pytest.MonkeyPatch, capsys):
     """Auto-detect treats non-version target as tool name (wheel install)."""
     tracked_install: list = []
 
@@ -386,9 +375,7 @@ def test_main_install_auto_detect_invalid_version(
 # ---- ``uninstall`` subcommand -----------------------------------------
 
 
-def test_main_uninstall_subcommand(
-    monkeypatch: pytest.MonkeyPatch, tmp_path, capsys
-):
+def test_main_uninstall_subcommand(monkeypatch: pytest.MonkeyPatch, tmp_path, capsys):
     """``clang-tools uninstall 12`` removes installed tools."""
     tool_name = "clang-format"
     version = "12"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -200,6 +200,21 @@ def test_main_install_wheel_success(monkeypatch: pytest.MonkeyPatch, capsys):
     assert result.err == ""
 
 
+def test_main_install_wheel_unsupported_tool(
+    monkeypatch: pytest.MonkeyPatch, capsys
+):
+    """``--wheel`` with a binary-only tool name shows error."""
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["clang-tools", "install", "clang-query", "--wheel"],
+    )
+    exit_code = main()
+    result = capsys.readouterr()
+    assert "is not available as a wheel" in result.err
+    assert exit_code == 1
+
+
 def test_main_install_wheel_failure(monkeypatch: pytest.MonkeyPatch, capsys):
     """``--wheel`` with a failing _wheel_install returns 1."""
     monkeypatch.setattr(

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -157,3 +157,9 @@ def test_check_install_os_unsupported(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr("platform.system", lambda: "SunOS")
     with pytest.raises(SystemExit, match="sunos is not currently supported"):
         check_install_os()
+
+
+def test_check_install_arch_amd64(monkeypatch: pytest.MonkeyPatch):
+    """Tests check_install_arch returns 'amd64' for x86_64 machines."""
+    monkeypatch.setattr("platform.machine", lambda: "x86_64")
+    assert check_install_arch() == "amd64"


### PR DESCRIPTION
## Summary

Eliminates the binary/wheel CLI split by providing a single unified `clang-tools` command.

### Before (confusing for users)

```bash
clang-tools --install 18              # binary only
clang-tools-wheel --tool clang-format  # wheel only
```

### After (unified)

```bash
clang-tools install 18                 # auto-detect (binary first, fallback wheel)
clang-tools install 18 --binary       # force binary
clang-tools install 18 --wheel        # force wheel
clang-tools install clang-format --wheel           # wheel by tool name (latest)
clang-tools install clang-format --wheel --version 21  # wheel by tool + version
clang-tools uninstall 18              # remove installed tools
```

## Auto-detection logic

| Target type | Behavior |
|-------------|----------|
| Version in range (e.g. 18) | Try binary → fallback to wheel |
| Version out of range (e.g. 99) | Wheel only |
| Tool name (e.g. clang-format) | Wheel only |
| Unknown target | Error with helpful message |

## Backward compatibility

Legacy `--install`/`--uninstall` top-level flags are preserved:

```bash
clang-tools --install 13 --tool clang-format   # still works (deprecated)
clang-tools --uninstall 13                      # still works (deprecated)
```

## Changes

- **`clang_tools/main.py`**: Rewritten with subcommand-based CLI, auto-detection, and fallback logic
- **`pyproject.toml`**: Removed `clang-tools-wheel` entry point
- **Tests**: 57 tests covering all new CLI paths, auto-detection, error cases, and legacy compat
- **Docs**: Updated README, mkdocs, API docs, and CLI reference to reflect unified command
- Full test suite: **142 passed** (existing + new)

## Breaking change

The separate `clang-tools-wheel` command is removed. Users should migrate:

| Old | New |
|-----|-----|
| `clang-tools-wheel --tool clang-format` | `clang-tools install clang-format --wheel` |
| `clang-tools-wheel --tool clang-tidy --version 21` | `clang-tools install clang-tidy --wheel --version 21` |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redesigned CLI: subcommands `clang-tools install <target>` and `clang-tools uninstall <version>`; explicit `--binary` / `--wheel` options with auto-detect fallback.
  * Wheel installs via `clang-tools install --wheel` with optional `--version`; wheel install support limited to supported tools.

* **Documentation**
  * Updated CLI usage examples, docs, README, and added "Related Projects" and "Acknowledgments".

* **Tests**
  * Expanded unit/integration tests covering install/uninstall, auto-detect, wheel behavior, and edge cases.

* **Chores**
  * Removed standalone `clang-tools-wheel` command; CI updated to use unified CLI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->