### PR TITLE
chore: drop Python 3.9 support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ classifiers = [
     "Operating System :: Microsoft :: Windows",
     "Operating System :: POSIX :: Linux",
     "Operating System :: MacOS",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",


### PR DESCRIPTION
Remove the `Programming Language :: Python :: 3.9` classifier from `pyproject.toml`.  
  
CI workflows already use Python 3.10+ everywhere.

Closes #172

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project metadata to reflect support for Python versions 3.10 through 3.14, removing support for Python 3.9.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->