### PR TITLE
docs: add clang-include-cleaner and clang-apply-replacements to wheel tools documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 [![Downloads](https://img.shields.io/pypi/dw/clang-tools)](https://pypistats.org/packages/clang-tools)
 [![cpp-linter hub](https://img.shields.io/badge/%F0%9F%8F%A0_cpp--linter_hub-%E2%86%90_home-22863a)](https://cpp-linter.github.io/)
 
-Easily install `clang-format`, `clang-tidy`, `clang-query`, and
-`clang-apply-replacements` static binaries or Python wheels using the
-`clang-tools` CLI.
+Easily install `clang-format`, `clang-tidy`, `clang-query`,
+`clang-apply-replacements`, and `clang-include-cleaner` static binaries or
+Python wheels using the `clang-tools` CLI.
 
 > [!IMPORTANT]
 > This package only manages binary executables
@@ -17,8 +17,8 @@ Easily install `clang-format`, `clang-tidy`, `clang-query`, and
 > any binary executable installed from other sources (like LLVM
 > releases).
 >
-> For Python wheels, this CLI only supports `clang-format` and
-> `clang-tidy` tools.
+> For Python wheels, this CLI supports `clang-format`, `clang-tidy`,
+> `clang-include-cleaner`, and `clang-apply-replacements` tools.
 
 📖 **Full documentation:** [cpp-linter.github.io/clang-tools-pip](https://cpp-linter.github.io/clang-tools-pip/)
 
@@ -123,6 +123,8 @@ For more details, visit
 
 - [clang-format](https://pypi.org/project/clang-format/#history)
 - [clang-tidy](https://pypi.org/project/clang-tidy/#history)
+- [clang-include-cleaner](https://pypi.org/project/clang-include-cleaner/#history)
+- [clang-apply-replacements](https://pypi.org/project/clang-apply-replacements/#history)
 
 Check the respective PyPI pages for available versions and platform support.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,9 +5,9 @@
 [![Platform](https://img.shields.io/badge/platform-linux--64%20%7C%20linux--arm64%20%7C%20win--64%20%7C%20osx--64%20%7C%20osx--arm64%20-blue)](https://pypi.org/project/clang-tools/)
 [![Downloads](https://img.shields.io/pypi/dw/clang-tools)](https://pypistats.org/packages/clang-tools)
 
-Easily install `clang-format`, `clang-tidy`, `clang-query`, and
-`clang-apply-replacements` static binaries or Python wheels using the
-`clang-tools` CLI.
+Easily install `clang-format`, `clang-tidy`, `clang-query`,
+`clang-apply-replacements`, and `clang-include-cleaner` static binaries or
+Python wheels using the `clang-tools` CLI.
 
 !!! important
     This package only manages binary executables
@@ -15,8 +15,8 @@ Easily install `clang-format`, `clang-tidy`, `clang-query`, and
     executable script. It does not intend to change or modify any binary
     executable installed from other sources (like LLVM releases).
 
-    For Python wheels, this CLI only supports `clang-format` and
-    `clang-tidy` tools.
+    For Python wheels, this CLI supports `clang-format`, `clang-tidy`,
+    `clang-include-cleaner`, and `clang-apply-replacements` tools.
 
 ## Features
 
@@ -144,5 +144,7 @@ The following Python wheels are supported:
 
 - [clang-format](https://pypi.org/project/clang-format/#history)
 - [clang-tidy](https://pypi.org/project/clang-tidy/#history)
+- [clang-include-cleaner](https://pypi.org/project/clang-include-cleaner/#history)
+- [clang-apply-replacements](https://pypi.org/project/clang-apply-replacements/#history)
 
 Check the respective PyPI pages for available versions and platform support.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,9 +4,9 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "clang_tools"
-description = "Install clang-tools (clang-format, clang-tidy, clang-query, clang-apply-replacements) with pip"
+description = "Install clang-tools (clang-format, clang-tidy, clang-query, clang-apply-replacements, clang-include-cleaner) with pip"
 readme = "README.md"
-keywords = ["clang", "clang-tools", "clang-extra", "clang-tidy", "clang-format", "clang-query", "clang-apply-replacements"]
+keywords = ["clang", "clang-tools", "clang-extra", "clang-tidy", "clang-format", "clang-query", "clang-apply-replacements", "clang-include-cleaner"]
 license = "MIT"
 authors = [
     { name = "Xianpeng Shen", email = "xianpeng.shen@gmail.com" },


### PR DESCRIPTION
## Summary

Updates documentation to reflect that `clang-include-cleaner` and `clang-apply-replacements` are now supported as Python wheels, matching the already-implemented `WHEEL_TOOLS` set in `main.py`.

## Changes

- **`README.md`** — Updated intro, wheel tools callout ("only supports" → "supports" all 4), added PyPI links
- **`docs/index.md`** — Same updates to intro, `!!! important` admonition, and PyPI links
- **`pyproject.toml`** — Added `clang-include-cleaner` to `description` and `keywords`

## Context

The `WHEEL_TOOLS` set in `main.py` already included these tools and tests covered them, but the documentation still claimed only `clang-format` and `clang-tidy` were supported as wheels.
