### PR TITLE
docs: update feature section and add win-arm64 platform badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,23 +23,22 @@ Python wheels using the `clang-tools` CLI.
 
 ## Features
 
-- **Unified CLI** — A single `clang-tools install` command that supports installing clang tools via **static binaries** or **Python wheels**, with automatic fallback.
-- **Auto-detection & fallback** — Tries static binary installation first; if the binary is unavailable (e.g., unsupported version, network issue), gracefully falls back to wheel installation.
-- **Static binaries** — Binaries are statically linked from upstream LLVM for improved portability across Linux, macOS, and Windows.
-- **SHA512 checksum verification** — Every download is verified against its published checksum, ensuring:
-  1. Downloads are not corrupted.
-  2. Outdated binaries are detected and re-downloaded.
-- **Dynamic PyPI version resolution** — Wheel versions are resolved live from PyPI's JSON API — no hardcoded version list to maintain.
-- **Symlink management** — Versioned binaries (e.g., `clang-tidy-18`) are symbolically linked to unversioned names (e.g., `clang-tidy`) for convenient invocation.
+- Install `clang-format`, `clang-tidy`, `clang-query`, `clang-apply-replacements`, and `clang-include-cleaner` via a single `clang-tools` CLI.
+- Supports both **static binaries** (standalone executables) and **Python wheels** (installed via pip).
+- Automatically uses static binaries when available; falls back to wheels if not.
+- Works on Linux, macOS, and Windows (x86_64 and ARM64).
+- Choose a specific LLVM version (11–22) or install the latest.
+- Install only the tools you need with `--tool`.
+- Uses SHA512 checksums to verify downloaded binaries.
+- Creates unversioned symlinks (e.g., `clang-format`) alongside versioned binaries (`clang-format-18`) for convenience.
 
   > [!NOTE]
   > To create symbolic links on Windows, you must enable developer mode
   > from the Windows settings under "Privacy & security" > "For developers"
   > category.
 
-- **Selective installation** — Install only the tools you need with `--tool`, or target a specific version.
-- **Customizable install path** — Use `--directory` to install binaries to any directory.
-- **Uninstall support** — Remove installed tools cleanly with `clang-tools uninstall`.
+- Install to any directory with `--directory`.
+- Uninstall with `clang-tools uninstall`.
 
 ## Install clang-tools CLI
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![PyPI version](https://img.shields.io/pypi/v/clang-tools?color=blue)](https://pypi.org/project/clang-tools/)
-[![Platform](https://img.shields.io/badge/platform-linux--64%20%7C%20linux--arm64%20%7C%20win--64%20%7C%20osx--64%20%7C%20osx--arm64%20-blue)](https://pypi.org/project/clang-tools/)
+[![Platform](https://img.shields.io/badge/platform-linux--64%20%7C%20linux--arm64%20%7C%20win--64%20%7C%20win--arm64%20%7C%20osx--64%20%7C%20osx--arm64-blue)](https://pypi.org/project/clang-tools/)
 [![Test](https://github.com/cpp-linter/clang-tools-pip/actions/workflows/test.yml/badge.svg)](https://github.com/cpp-linter/clang-tools-pip/actions/workflows/test.yml)
 [![codecov](https://codecov.io/gh/cpp-linter/clang-tools-pip/branch/main/graph/badge.svg?token=40G5ZOIRRR)](https://codecov.io/gh/cpp-linter/clang-tools-pip)
 [![SonarCloud](https://sonarcloud.io/api/project_badges/measure?project=cpp-linter_clang-tools-pip&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=cpp-linter_clang-tools-pip)
@@ -23,22 +23,23 @@ Python wheels using the `clang-tools` CLI.
 
 ## Features
 
-- Install and manage clang tools binaries and Python wheels.
-- Binaries are statically linked (from upstream LLVM) for improved portability.
-- Binaries can be specified or installed for increased flexibility.
-- Binaries are checked with SHA512 checksum. This ensures:
+- **Unified CLI** — A single `clang-tools install` command that supports installing clang tools via **static binaries** or **Python wheels**, with automatic fallback.
+- **Auto-detection & fallback** — Tries static binary installation first; if the binary is unavailable (e.g., unsupported version, network issue), gracefully falls back to wheel installation.
+- **Static binaries** — Binaries are statically linked from upstream LLVM for improved portability across Linux, macOS, and Windows.
+- **SHA512 checksum verification** — Every download is verified against its published checksum, ensuring:
   1. Downloads are not corrupted.
-  2. Old binary builds can be updated.
-- Installed binaries are symbolically linked for better cross-platform usage.
-  For example (on Windows), the `clang-tidy-13.exe` binary executable can
-  also be invoked with the symbolic link titled `clang-tidy.exe`
+  2. Outdated binaries are detected and re-downloaded.
+- **Dynamic PyPI version resolution** — Wheel versions are resolved live from PyPI's JSON API — no hardcoded version list to maintain.
+- **Symlink management** — Versioned binaries (e.g., `clang-tidy-18`) are symbolically linked to unversioned names (e.g., `clang-tidy`) for convenient invocation.
 
   > [!NOTE]
   > To create symbolic links on Windows, you must enable developer mode
   > from the Windows settings under "Privacy & security" > "For developers"
   > category.
 
-- Customizable install path.
+- **Selective installation** — Install only the tools you need with `--tool`, or target a specific version.
+- **Customizable install path** — Use `--directory` to install binaries to any directory.
+- **Uninstall support** — Remove installed tools cleanly with `clang-tools uninstall`.
 
 ## Install clang-tools CLI
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,7 @@
 [![Downloads](https://img.shields.io/pypi/dw/clang-tools)](https://pypistats.org/packages/clang-tools)
 [![cpp-linter hub](https://img.shields.io/badge/%F0%9F%8F%A0_cpp--linter_hub-%E2%86%90_home-22863a)](https://cpp-linter.github.io/)
 
-Easily install `clang-format`, `clang-tidy`, `clang-query`,
-`clang-apply-replacements`, and `clang-include-cleaner` static binaries or
+Easily install `clang-format`, `clang-tidy`, `clang-query`, `clang-apply-replacements`, and `clang-include-cleaner` static binaries or
 Python wheels using the `clang-tools` CLI.
 
 > [!IMPORTANT]
@@ -110,14 +109,13 @@ clang-tools install clang-format --wheel --version 21
 
 ### clang tools binaries
 
-| Platform | 22 | 21 | 20 | 19 | 18 | 17 | 16 | 15 | 14 | 13 | 12 | 11 |
-|----------|----|----|----|----|----|----|----|----|----|----|----|----|
-| Linux | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
-| Windows | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
-| macOS | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
+- clang-format
+- clang-tidy
+- clang-query
+- clang-apply-replacements
+- clang-include-cleaner
 
-For more details, visit
-[clang-tools-static-binaries](https://github.com/cpp-linter/clang-tools-static-binaries).
+For more details, visit [clang-tools-static-binaries](https://github.com/cpp-linter/clang-tools-static-binaries).
 
 ### clang tools Python wheels
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,23 +20,22 @@ Python wheels using the `clang-tools` CLI.
 
 ## Features
 
-- **Unified CLI** — A single `clang-tools install` command that supports installing clang tools via **static binaries** or **Python wheels**, with automatic fallback.
-- **Auto-detection & fallback** — Tries static binary installation first; if the binary is unavailable (e.g., unsupported version, network issue), gracefully falls back to wheel installation.
-- **Static binaries** — Binaries are statically linked from upstream LLVM for improved portability across Linux, macOS, and Windows.
-- **SHA512 checksum verification** — Every download is verified against its published checksum, ensuring:
-    1. Downloads are not corrupted.
-    2. Outdated binaries are detected and re-downloaded.
-- **Dynamic PyPI version resolution** — Wheel versions are resolved live from PyPI's JSON API — no hardcoded version list to maintain.
-- **Symlink management** — Versioned binaries (e.g., `clang-tidy-18`) are symbolically linked to unversioned names (e.g., `clang-tidy`) for convenient invocation.
+- Install `clang-format`, `clang-tidy`, `clang-query`, `clang-apply-replacements`, and `clang-include-cleaner` via a single `clang-tools` CLI.
+- Supports both **static binaries** (standalone executables) and **Python wheels** (installed via pip).
+- Automatically uses static binaries when available; falls back to wheels if not.
+- Works on Linux, macOS, and Windows (x86_64 and ARM64).
+- Choose a specific LLVM version (11–22) or install the latest.
+- Install only the tools you need with `--tool`.
+- Uses SHA512 checksums to verify downloaded binaries.
+- Creates unversioned symlinks (e.g., `clang-format`) alongside versioned binaries (`clang-format-18`) for convenience.
 
     !!! note
         To create symbolic links on Windows, you must enable developer mode
         from the Windows settings under "Privacy & security" > "For developers"
         category.
 
-- **Selective installation** — Install only the tools you need with `--tool`, or target a specific version.
-- **Customizable install path** — Use `--directory` to install binaries to any directory.
-- **Uninstall support** — Remove installed tools cleanly with `clang-tools uninstall`.
+- Install to any directory with `--directory`.
+- Uninstall with `clang-tools uninstall`.
 
 ## Install clang-tools CLI
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 [![Test](https://github.com/cpp-linter/clang-tools-pip/actions/workflows/test.yml/badge.svg)](https://github.com/cpp-linter/clang-tools-pip/actions/workflows/test.yml)
 [![codecov](https://codecov.io/gh/cpp-linter/clang-tools-pip/branch/main/graph/badge.svg?token=40G5ZOIRRR)](https://codecov.io/gh/cpp-linter/clang-tools-pip)
 [![SonarCloud](https://sonarcloud.io/api/project_badges/measure?project=cpp-linter_clang-tools-pip&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=cpp-linter_clang-tools-pip)
-[![Platform](https://img.shields.io/badge/platform-linux--64%20%7C%20linux--arm64%20%7C%20win--64%20%7C%20osx--64%20%7C%20osx--arm64%20-blue)](https://pypi.org/project/clang-tools/)
+[![Platform](https://img.shields.io/badge/platform-linux--64%20%7C%20linux--arm64%20%7C%20win--64%20%7C%20win--arm64%20%7C%20osx--64%20%7C%20osx--arm64-blue)](https://pypi.org/project/clang-tools/)
 [![Downloads](https://img.shields.io/pypi/dw/clang-tools)](https://pypistats.org/packages/clang-tools)
 
 Easily install `clang-format`, `clang-tidy`, `clang-query`,
@@ -20,21 +20,23 @@ Python wheels using the `clang-tools` CLI.
 
 ## Features
 
-- Install and manage clang tools binaries and Python wheels.
-- Binaries are statically linked (from upstream LLVM) for improved portability.
-- Binaries can be specified or installed for increased flexibility.
-- Binaries are checked with SHA512 checksum. This ensures:
+- **Unified CLI** — A single `clang-tools install` command that supports installing clang tools via **static binaries** or **Python wheels**, with automatic fallback.
+- **Auto-detection & fallback** — Tries static binary installation first; if the binary is unavailable (e.g., unsupported version, network issue), gracefully falls back to wheel installation.
+- **Static binaries** — Binaries are statically linked from upstream LLVM for improved portability across Linux, macOS, and Windows.
+- **SHA512 checksum verification** — Every download is verified against its published checksum, ensuring:
     1. Downloads are not corrupted.
-    2. Old binary builds can be updated.
-- Installed binaries are symbolically linked for better cross-platform usage.
-  For example (on Windows), the `clang-tidy-13.exe` binary executable can
-  also be invoked with the symbolic link titled `clang-tidy.exe`
+    2. Outdated binaries are detected and re-downloaded.
+- **Dynamic PyPI version resolution** — Wheel versions are resolved live from PyPI's JSON API — no hardcoded version list to maintain.
+- **Symlink management** — Versioned binaries (e.g., `clang-tidy-18`) are symbolically linked to unversioned names (e.g., `clang-tidy`) for convenient invocation.
 
     !!! note
         To create symbolic links on Windows, you must enable developer mode
         from the Windows settings under "Privacy & security" > "For developers"
         category.
-- Customizable install path.
+
+- **Selective installation** — Install only the tools you need with `--tool`, or target a specific version.
+- **Customizable install path** — Use `--directory` to install binaries to any directory.
+- **Uninstall support** — Remove installed tools cleanly with `clang-tools uninstall`.
 
 ## Install clang-tools CLI
 


### PR DESCRIPTION
## Summary

Updated the feature section to accurately reflect the project's capabilities and added `win--arm64` to the platform badge.

## Changes

### Badge
- Added `win--arm64` to the platform badge in both `README.md` and `docs/index.md`

### Features section (rewrite)
The old feature section had several issues:
- "Binaries can be specified or installed for increased flexibility" was vague
- Missing the biggest feature: unified CLI with auto-detection/fallback between binary and wheel
- Missing dynamic PyPI version resolution for wheels
- Missing uninstall support

The new section highlights:
- **Unified CLI** — single command for both binary and wheel installation
- **Auto-detection & fallback** — tries binary first, falls back to wheel
- **Static binaries** — statically linked from upstream LLVM
- **SHA512 verification** — download integrity checks
- **Dynamic PyPI resolution** — wheel versions resolved live from PyPI
- **Symlink management** — versioned + unversioned binary names
- **Selective installation** — `--tool` and version targeting
- **Customizable install path** — `--directory`
- **Uninstall support** — `clang-tools uninstall`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced README and documentation with improved feature descriptions, including unified installation command, static-binary-first approach with fallback, checksum verification, dynamic version resolution, and additional CLI customization options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->