### PR TITLE
fix: --binary mode accepts tool name as positional arg with --version

### DIFF
--- a/clang_tools/main.py
+++ b/clang_tools/main.py
@@ -87,16 +87,30 @@ def _handle_wheel(args: argparse.Namespace) -> int:
 
 
 def _handle_binary(args: argparse.Namespace) -> int:
-    """Handle ``install --binary`` subcommand."""
+    """Handle ``install --binary`` subcommand.
+
+    Supports two argument styles (consistent with ``--wheel``):
+
+    * ``clang-tools install <version> --tool <tool> --binary``
+    * ``clang-tools install <tool> --version <VER> --binary``
+    """
     target: str = args.target
-    if not _is_version_like(target):
-        print(
-            f"{YELLOW}Error: --binary requires a version number"
-            f" (got '{target}'){RESET_COLOR}",
-            file=sys.stderr,
-        )
-        return 1
-    version = Version(target)
+    if _is_version_like(target):
+        version = Version(target)
+        tools = args.tool
+    else:
+        # target is a tool name — use --version for the version number
+        if args.explicit_version is None:
+            print(
+                f"{YELLOW}Error: --binary requires a version number"
+                f" (got '{target}'). "
+                f"Use e.g. 'clang-tools install {target}"
+                f" --version <VER> --binary'{RESET_COLOR}",
+                file=sys.stderr,
+            )
+            return 1
+        version = Version(args.explicit_version)
+        tools = [target]
     if version.info == (0, 0, 0):
         print(
             f"{YELLOW}The version specified is not a semantic"
@@ -106,7 +120,7 @@ def _handle_binary(args: argparse.Namespace) -> int:
         return 1
     install_clang_tools(
         version,
-        args.tool,
+        tools,
         args.directory,
         args.overwrite,
         args.no_progress_bar,
@@ -201,7 +215,7 @@ def get_parser() -> argparse.ArgumentParser:
         dest="explicit_version",
         default=None,
         metavar="VER",
-        help="Explicit version for wheel install (when target is a tool name)",
+        help="Explicit version (when target is a tool name, for both --wheel and --binary)",
     )
     install_p.add_argument(
         "-t",

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -167,6 +167,60 @@ def test_main_install_binary_invalid_version(monkeypatch: pytest.MonkeyPatch, ca
     assert exit_code == 1
 
 
+def test_main_install_binary_tool_as_positional_with_version(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+):
+    """
+    ``--binary`` accepts tool name as positional with ``--version``
+    (consistent with ``--wheel``).
+    """
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "clang-tools",
+            "install",
+            "clang-format",
+            "--version",
+            "12",
+            "--binary",
+            "--directory",
+            str(tmp_path),
+            "--no-progress-bar",
+        ],
+    )
+    exit_code = main()
+    assert exit_code == 0
+    bin_path = tmp_path / f"clang-format-12{suffix}"
+    assert bin_path.exists()
+
+
+def test_main_install_binary_tool_as_positional_bad_semver(
+    monkeypatch: pytest.MonkeyPatch, capsys
+):
+    """
+    ``--binary`` with tool name as positional and a zeroed-out ``--version``
+    (e.g. 0.0.0) shows the semantic-version error.
+    """
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "clang-tools",
+            "install",
+            "clang-tidy",
+            "--version",
+            "0.0.0",
+            "--binary",
+        ],
+    )
+    exit_code = main()
+    result = capsys.readouterr()
+    assert "not a semantic" in result.err
+    assert exit_code == 1
+
+
 def test_main_install_binary_and_wheel_mutex(monkeypatch: pytest.MonkeyPatch, capsys):
     """``--binary`` and ``--wheel`` together is an error."""
     monkeypatch.setattr(


### PR DESCRIPTION
## Description

Fixes #192

The `--binary` mode CLI was inconsistent with `--wheel`: it only accepted the version number as the positional `target` argument, rejecting tool names even when `--version` was explicitly provided.

Now `--binary` supports both argument styles, matching `--wheel`:

**Before (broken):**
```bash
clang-tools install clang-tidy --version 17 --binary   # Error: --binary requires a version number (got 'clang-tidy')
```

**After (fixed):**
```bash
clang-tools install clang-tidy --version 17 --binary   # ✓ works
clang-tools install 17 --tool clang-tidy --binary       # ✓ already worked
```

## Changes

- `clang_tools/main.py`: Refactored `_handle_binary()` to mirror `_handle_wheel()` — if `target` is version-like, use it as the version; otherwise treat it as a tool name and use `--version` for the version number. Updated the `--version` help text to reflect it works for both modes.

## Testing

- All 162 existing tests pass (42 `test_main.py` + 120 others)
- Manually verified all three scenarios:
  1. Version as positional with `--tool` (existing behavior)
  2. Tool as positional with `--version` (new behavior)
  3. Tool as positional without `--version` (clear error message)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The binary installation command now supports two invocation modes: semantic version targeting or specific tool-name targeting with the `--version` flag.

* **Documentation**
  * Enhanced help text to clarify the `--version` argument's applicability to both wheel and binary installation options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->