### PR TITLE
refactor: redesign CLI with positional tool names

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,7 +97,7 @@ jobs:
         run: pip install --no-cache-dir dist/*.whl
 
       - name: Install clang-tools binaries
-        run: clang-tools install ${{ matrix.version }} --tool clang-format clang-tidy clang-query clang-apply-replacements
+        run: clang-tools install clang-format clang-tidy clang-query clang-apply-replacements --version ${{ matrix.version }}
 
       - name: Show path of clang-tools binaries
         shell: bash
@@ -159,7 +159,7 @@ jobs:
             fi
 
             echo "::group::Installing $tool wheel v$ver"
-            clang-tools install "$tool" --wheel --version "$ver"
+            clang-tools install "$tool" --version "$ver" --backend wheel
             "$tool" --version
             local out=$("$tool" --version)
             echo "$tool version: $out"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -159,7 +159,7 @@ jobs:
             fi
 
             echo "::group::Installing $tool wheel v$ver"
-            clang-tools install "$tool" --version "$ver" --backend wheel
+            clang-tools install "$tool" --version "$ver"
             "$tool" --version
             local out=$("$tool" --version)
             echo "$tool version: $out"

--- a/README.md
+++ b/README.md
@@ -70,17 +70,26 @@ For a full list of CLI options, see the [documentation](https://cpp-linter.githu
 ### Install binaries
 
 ```bash
-# Install version 13 binaries (auto-detects binary vs wheel)
-clang-tools install 13
+# Install latest clang-format (auto-detects: tries binary with --version, else wheel)
+clang-tools install clang-format
 
-# Force binary installation
-clang-tools install 13 --binary
+# Install specific version (auto-detect: binary first, fall back to wheel)
+clang-tools install clang-format --version 13
+
+# Install multiple tools with a version
+clang-tools install clang-format clang-tidy --version 13
 
 # Install to a specified directory
-clang-tools install 13 --directory .
+clang-tools install clang-format --version 13 --directory .
 
-# Install specific tools
-clang-tools install 14 --tool clang-format clang-query
+# Force binary installation
+clang-tools install clang-format --version 13 --backend binary
+
+# Force wheel installation
+clang-tools install clang-format --backend wheel
+
+# Install a specific wheel version
+clang-tools install clang-format --version 21 --backend wheel
 ```
 
 If the installed directory is in your path:
@@ -88,16 +97,6 @@ If the installed directory is in your path:
 ```bash
 clang-format-13 --version
 # clang-format version 13.0.0
-```
-
-### Install wheels
-
-```bash
-# Install latest clang-format wheel
-clang-tools install clang-format --wheel
-
-# Install specific version
-clang-tools install clang-format --wheel --version 21
 ```
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -82,14 +82,6 @@ clang-tools install clang-format clang-tidy --version 13
 # Install to a specified directory
 clang-tools install clang-format --version 13 --directory .
 
-# Force binary installation
-clang-tools install clang-format --version 13 --backend binary
-
-# Force wheel installation
-clang-tools install clang-format --backend wheel
-
-# Install a specific wheel version
-clang-tools install clang-format --version 21 --backend wheel
 ```
 
 If the installed directory is in your path:
@@ -103,6 +95,18 @@ clang-format-13 --version
 > Wheel installation is primarily intended for
 > cpp-linter projects. For general use, install wheels directly
 > using `pip`, `pipx`, or `uv`.
+
+### Install wheels
+
+To install specific tools as Python wheels:
+
+```bash
+# Install latest clang-format wheel
+clang-tools install clang-format --version 21
+
+# Install latest clang-tidy wheel
+clang-tools install clang-tidy --version 21
+```
 
 ## Supported Clang Tools
 

--- a/README.md
+++ b/README.md
@@ -91,10 +91,10 @@ clang-format-13 --version
 # clang-format version 13.0.0
 ```
 
-> [!IMPORTANT]
-> Wheel installation is primarily intended for
-> cpp-linter projects. For general use, install wheels directly
-> using `pip`, `pipx`, or `uv`.
+> [!NOTE]
+> Wheel installation resolves the latest matching version from PyPI
+> (e.g. `--version 18` finds `18.1.8`). If you know the exact version,
+> `pip install <tool>==<version>` is equivalent and more direct.
 
 ### Install wheels
 

--- a/clang_tools/main.py
+++ b/clang_tools/main.py
@@ -141,9 +141,7 @@ def _install_auto(
         v = Version(version)
         if v.info != (0, 0, 0):
             try:
-                install_clang_tools(
-                    v, tools, directory, overwrite, no_progress_bar
-                )
+                install_clang_tools(v, tools, directory, overwrite, no_progress_bar)
                 return 0
             except (OSError, ValueError) as exc:
                 print(

--- a/clang_tools/main.py
+++ b/clang_tools/main.py
@@ -4,20 +4,13 @@
 
 The unified CLI entry point for installing and managing clang-tools.
 
-Supports two installation backends — binary (static builds) and wheel (PyPI)
-— via the ``--backend`` flag or auto-detection.
-
 Usage::
 
-    # Install one or more tools with auto-detected backend
+    # Install one or more tools (auto-detect: binary→wheel)
     clang-tools install clang-format clang-tidy --version 18
 
     # Install latest version (wheel only, no version needed)
     clang-tools install clang-format
-
-    # Explicitly choose backend
-    clang-tools install clang-format --version 18 --backend binary
-    clang-tools install clang-format --backend wheel
 
     # Uninstall
     clang-tools uninstall clang-format --version 12
@@ -68,75 +61,19 @@ def _wheel_install(tools: list[str], version: Optional[str]) -> int:
     return 0 if ok else 1
 
 
-# ---------------------------------------------------------------------------
-#  Backend handlers
-# ---------------------------------------------------------------------------
+def _handle_install(args: argparse.Namespace) -> int:
+    """Handle ``install`` subcommand — auto-detect backend.
 
-
-def _install_binary(
-    tools: list[str],
-    version: Optional[str],
-    directory: str,
-    overwrite: bool,
-    no_progress_bar: bool,
-) -> int:
-    """Install tool(s) using the binary (static build) backend.
-
-    ``--version`` is required for this backend.
+    When ``--version`` is given, binary (static build) is tried first;
+    on failure it falls back to wheel (PyPI pip install).
+    Without ``--version``, only wheel is possible.
     """
-    if version is None:
-        print(
-            f"{YELLOW}Error: --backend binary requires --version{RESET_COLOR}",
-            file=sys.stderr,
-        )
-        return 1
-    v = Version(version)
-    if v.info == (0, 0, 0):
-        print(
-            f"{YELLOW}The version specified is not a semantic"
-            f" specification{RESET_COLOR}",
-            file=sys.stderr,
-        )
-        return 1
-    try:
-        install_clang_tools(v, tools, directory, overwrite, no_progress_bar)
-        return 0
-    except (OSError, ValueError) as exc:
-        print(
-            f"{YELLOW}Binary install failed: {exc}{RESET_COLOR}",
-            file=sys.stderr,
-        )
-        return 1
+    tools = args.tools
+    version = args.explicit_version
+    directory = args.directory
+    overwrite = args.overwrite
+    no_progress_bar = args.no_progress_bar
 
-
-def _install_wheel(tools: list[str], version: Optional[str]) -> int:
-    """Install tool(s) using the wheel (PyPI) backend.
-
-    Each tool must be in :data:`WHEEL_TOOLS`.
-    """
-    for tool in tools:
-        if tool not in WHEEL_TOOLS:
-            print(
-                f"{YELLOW}Error: '{tool}' is not available as a"
-                f" wheel. Supported: "
-                f"{', '.join(sorted(WHEEL_TOOLS))}{RESET_COLOR}",
-                file=sys.stderr,
-            )
-            return 1
-    return _wheel_install(tools, version)
-
-
-def _install_auto(
-    tools: list[str],
-    version: Optional[str],
-    directory: str,
-    overwrite: bool,
-    no_progress_bar: bool,
-) -> int:
-    """Auto-detect: try binary first (when ``--version`` given), fall back to wheel.
-
-    When no ``--version`` is provided, only wheel installation is possible.
-    """
     if version is not None:
         v = Version(version)
         if v.info != (0, 0, 0):
@@ -160,21 +97,6 @@ def _install_auto(
             )
             return 1
     return _wheel_install(tools, version)
-
-
-def _handle_install(args: argparse.Namespace) -> int:
-    """Dispatch ``install`` subcommand based on ``--backend``."""
-    tools = args.tools
-    version = args.explicit_version
-    directory = args.directory
-    overwrite = args.overwrite
-    no_progress_bar = args.no_progress_bar
-
-    if args.backend == "binary":
-        return _install_binary(tools, version, directory, overwrite, no_progress_bar)
-    if args.backend == "wheel":
-        return _install_wheel(tools, version)
-    return _install_auto(tools, version, directory, overwrite, no_progress_bar)
 
 
 # ---------------------------------------------------------------------------
@@ -202,13 +124,8 @@ def get_parser() -> argparse.ArgumentParser:
         dest="explicit_version",
         default=None,
         metavar="VER",
-        help="Version to install (e.g. 18). Required for --backend binary.",
-    )
-    install_p.add_argument(
-        "--backend",
-        choices=("auto", "binary", "wheel"),
-        default="auto",
-        help="Installation backend: auto (default, binary\u2192wheel), binary, or wheel",
+        help="Version to install (e.g. 18). When specified, binary install"
+        " is tried first, falling back to wheel.",
     )
     install_p.add_argument(
         "-d",

--- a/clang_tools/main.py
+++ b/clang_tools/main.py
@@ -129,9 +129,37 @@ def _handle_binary(args: argparse.Namespace) -> int:
 
 
 def _handle_auto_detect(args: argparse.Namespace) -> int:
-    """Handle ``install`` without --binary/--wheel (auto-detect mode)."""
+    """Handle ``install`` without --binary/--wheel (auto-detect mode).
+
+    When *target* is a version number → try binary first, fall back to wheel.
+    When *target* is a tool name and ``--version`` is given → try binary first,
+    fall back to wheel.  When *target* is a tool name without ``--version`` →
+    wheel install only.
+    """
     target: str = args.target
     if not _is_version_like(target):
+        # target is a tool name
+        if args.explicit_version is not None:
+            # explicit version — try binary first, fall back to wheel
+            version = Version(args.explicit_version)
+            if version.info != (0, 0, 0):
+                try:
+                    install_clang_tools(
+                        version,
+                        [target],
+                        args.directory,
+                        args.overwrite,
+                        args.no_progress_bar,
+                    )
+                    return 0
+                except (OSError, ValueError) as exc:
+                    print(
+                        f"{YELLOW}Binary install failed"
+                        f" ({exc}), falling back to"
+                        f" wheel...{RESET_COLOR}",
+                        file=sys.stderr,
+                    )
+        # fall through to wheel (requires a known wheel tool)
         if target not in WHEEL_TOOLS:
             print(
                 f"{YELLOW}Unknown target '{target}'. Expected a"

--- a/clang_tools/main.py
+++ b/clang_tools/main.py
@@ -2,9 +2,25 @@
 ``clang_tools.main``
 --------------------
 
-The module containing the unified main entrypoint function.
-Supports both binary (static build) and wheel-based installation
-via a single ``clang-tools`` command.
+The unified CLI entry point for installing and managing clang-tools.
+
+Supports two installation backends — binary (static builds) and wheel (PyPI)
+— via the ``--backend`` flag or auto-detection.
+
+Usage::
+
+    # Install one or more tools with auto-detected backend
+    clang-tools install clang-format clang-tidy --version 18
+
+    # Install latest version (wheel only, no version needed)
+    clang-tools install clang-format
+
+    # Explicitly choose backend
+    clang-tools install clang-format --version 18 --backend binary
+    clang-tools install clang-format --backend wheel
+
+    # Uninstall
+    clang-tools uninstall clang-format --version 12
 """
 
 import argparse
@@ -14,17 +30,6 @@ from typing import Optional
 from .install import install_clang_tools, uninstall_clang_tools
 from . import RESET_COLOR, YELLOW
 from .util import Version
-
-
-def _is_version_like(target: str) -> bool:
-    """Check if *target* looks like a version number (e.g. ``"18"``, ``"18.1"``)."""
-    try:
-        parts = target.split(".")
-        for p in parts:
-            int(p)
-        return True
-    except ValueError:
-        return False
 
 
 #: Known tool names commonly installed as Python wheels.
@@ -63,156 +68,120 @@ def _wheel_install(tools: list[str], version: Optional[str]) -> int:
     return 0 if ok else 1
 
 
-def _validate_wheel_tool(target: str) -> bool:
-    """Print an error and return `False` if *target* is not a wheel tool."""
-    if target not in WHEEL_TOOLS:
+# ---------------------------------------------------------------------------
+#  Backend handlers
+# ---------------------------------------------------------------------------
+
+
+def _install_binary(
+    tools: list[str],
+    version: Optional[str],
+    directory: str,
+    overwrite: bool,
+    no_progress_bar: bool,
+) -> int:
+    """Install tool(s) using the binary (static build) backend.
+
+    ``--version`` is required for this backend.
+    """
+    if version is None:
         print(
-            f"{YELLOW}Error: '{target}' is not available as a"
-            f" wheel. Supported: "
-            f"{', '.join(sorted(WHEEL_TOOLS))}{RESET_COLOR}",
+            f"{YELLOW}Error: --backend binary requires --version{RESET_COLOR}",
             file=sys.stderr,
         )
-        return False
-    return True
-
-
-def _handle_wheel(args: argparse.Namespace) -> int:
-    """Handle ``install --wheel`` subcommand."""
-    target: str = args.target
-    if _is_version_like(target):
-        return _wheel_install(args.tool, target)
-    if not _validate_wheel_tool(target):
         return 1
-    return _wheel_install([target], args.explicit_version)
-
-
-def _handle_binary(args: argparse.Namespace) -> int:
-    """Handle ``install --binary`` subcommand.
-
-    Supports two argument styles (consistent with ``--wheel``):
-
-    * ``clang-tools install <version> --tool <tool> --binary``
-    * ``clang-tools install <tool> --version <VER> --binary``
-    """
-    target: str = args.target
-    if _is_version_like(target):
-        version = Version(target)
-        tools = args.tool
-    else:
-        # target is a tool name — use --version for the version number
-        if args.explicit_version is None:
-            print(
-                f"{YELLOW}Error: --binary requires a version number"
-                f" (got '{target}'). "
-                f"Use e.g. 'clang-tools install {target}"
-                f" --version <VER> --binary'{RESET_COLOR}",
-                file=sys.stderr,
-            )
-            return 1
-        version = Version(args.explicit_version)
-        tools = [target]
-    if version.info == (0, 0, 0):
+    v = Version(version)
+    if v.info == (0, 0, 0):
         print(
             f"{YELLOW}The version specified is not a semantic"
             f" specification{RESET_COLOR}",
             file=sys.stderr,
         )
         return 1
-    install_clang_tools(
-        version,
-        tools,
-        args.directory,
-        args.overwrite,
-        args.no_progress_bar,
-    )
-    return 0
+    try:
+        install_clang_tools(v, tools, directory, overwrite, no_progress_bar)
+        return 0
+    except (OSError, ValueError) as exc:
+        print(
+            f"{YELLOW}Binary install failed: {exc}{RESET_COLOR}",
+            file=sys.stderr,
+        )
+        return 1
 
 
-def _handle_auto_detect(args: argparse.Namespace) -> int:
-    """Handle ``install`` without --binary/--wheel (auto-detect mode).
+def _install_wheel(tools: list[str], version: Optional[str]) -> int:
+    """Install tool(s) using the wheel (PyPI) backend.
 
-    When *target* is a version number → try binary first, fall back to wheel.
-    When *target* is a tool name and ``--version`` is given → try binary first,
-    fall back to wheel.  When *target* is a tool name without ``--version`` →
-    wheel install only.
+    Each tool must be in :data:`WHEEL_TOOLS`.
     """
-    target: str = args.target
-    if not _is_version_like(target):
-        # target is a tool name
-        if args.explicit_version is not None:
-            # explicit version — try binary first, fall back to wheel
-            version = Version(args.explicit_version)
-            if version.info != (0, 0, 0):
-                try:
-                    install_clang_tools(
-                        version,
-                        [target],
-                        args.directory,
-                        args.overwrite,
-                        args.no_progress_bar,
-                    )
-                    return 0
-                except (OSError, ValueError) as exc:
-                    print(
-                        f"{YELLOW}Binary install failed"
-                        f" ({exc}), falling back to"
-                        f" wheel...{RESET_COLOR}",
-                        file=sys.stderr,
-                    )
-        # fall through to wheel (requires a known wheel tool)
-        if target not in WHEEL_TOOLS:
+    for tool in tools:
+        if tool not in WHEEL_TOOLS:
             print(
-                f"{YELLOW}Unknown target '{target}'. Expected a"
-                f" version number or one of: "
+                f"{YELLOW}Error: '{tool}' is not available as a"
+                f" wheel. Supported: "
                 f"{', '.join(sorted(WHEEL_TOOLS))}{RESET_COLOR}",
                 file=sys.stderr,
             )
             return 1
-        return _wheel_install([target], args.explicit_version)
+    return _wheel_install(tools, version)
 
-    version = Version(target)
-    if version.info == (0, 0, 0):
-        print(
-            f"{YELLOW}The version specified is not a semantic"
-            f" specification{RESET_COLOR}",
-            file=sys.stderr,
-        )
-        return 1
 
-    # try binary first, fall back to wheel
-    try:
-        install_clang_tools(
-            version,
-            args.tool,
-            args.directory,
-            args.overwrite,
-            args.no_progress_bar,
-        )
-        return 0
-    except (OSError, ValueError) as exc:
-        print(
-            f"{YELLOW}Binary install failed"
-            f" ({exc}), falling back to"
-            f" wheel...{RESET_COLOR}",
-            file=sys.stderr,
-        )
-    return _wheel_install(args.tool, target)
+def _install_auto(
+    tools: list[str],
+    version: Optional[str],
+    directory: str,
+    overwrite: bool,
+    no_progress_bar: bool,
+) -> int:
+    """Auto-detect: try binary first (when ``--version`` given), fall back to wheel.
+
+    When no ``--version`` is provided, only wheel installation is possible.
+    """
+    if version is not None:
+        v = Version(version)
+        if v.info != (0, 0, 0):
+            try:
+                install_clang_tools(
+                    v, tools, directory, overwrite, no_progress_bar
+                )
+                return 0
+            except (OSError, ValueError) as exc:
+                print(
+                    f"{YELLOW}Binary install failed"
+                    f" ({exc}), falling back to"
+                    f" wheel...{RESET_COLOR}",
+                    file=sys.stderr,
+                )
+    # fall back to wheel
+    for tool in tools:
+        if tool not in WHEEL_TOOLS:
+            print(
+                f"{YELLOW}Unknown tool '{tool}'. Expected one of: "
+                f"{', '.join(sorted(WHEEL_TOOLS))}{RESET_COLOR}",
+                file=sys.stderr,
+            )
+            return 1
+    return _wheel_install(tools, version)
 
 
 def _handle_install(args: argparse.Namespace) -> int:
-    """Dispatch ``install`` subcommand based on flags."""
-    if args.binary and args.wheel:
-        print(
-            f"{YELLOW}Error: --binary and --wheel are mutually exclusive{RESET_COLOR}",
-            file=sys.stderr,
-        )
-        return 1
+    """Dispatch ``install`` subcommand based on ``--backend``."""
+    tools = args.tools
+    version = args.explicit_version
+    directory = args.directory
+    overwrite = args.overwrite
+    no_progress_bar = args.no_progress_bar
 
-    if args.wheel:
-        return _handle_wheel(args)
-    if args.binary:
-        return _handle_binary(args)
-    return _handle_auto_detect(args)
+    if args.backend == "binary":
+        return _install_binary(tools, version, directory, overwrite, no_progress_bar)
+    if args.backend == "wheel":
+        return _install_wheel(tools, version)
+    return _install_auto(tools, version, directory, overwrite, no_progress_bar)
+
+
+# ---------------------------------------------------------------------------
+#  Parser
+# ---------------------------------------------------------------------------
 
 
 def get_parser() -> argparse.ArgumentParser:
@@ -222,36 +191,26 @@ def get_parser() -> argparse.ArgumentParser:
     )
     subparsers = parser.add_subparsers(dest="command", help="Available commands")
 
-    # --- ``clang-tools install <target>`` ---------------------------------
+    # --- ``clang-tools install <tool> [<tool> ...]`` --------------------
     install_p = subparsers.add_parser("install", help="Install clang-tools")
     install_p.add_argument(
-        "target",
-        help="Version number (e.g. 18) or tool name (e.g. clang-format)",
-    )
-    install_p.add_argument(
-        "--binary",
-        action="store_true",
-        help="Force binary (static build) installation",
-    )
-    install_p.add_argument(
-        "--wheel",
-        action="store_true",
-        help="Force wheel installation (resolves versions from PyPI)",
+        "tools",
+        nargs="+",
+        metavar="TOOL",
+        help="Tool name(s) to install (e.g. clang-format clang-tidy)",
     )
     install_p.add_argument(
         "--version",
         dest="explicit_version",
         default=None,
         metavar="VER",
-        help="Explicit version (when target is a tool name, for both --wheel and --binary)",
+        help="Version to install (e.g. 18). Required for --backend binary.",
     )
     install_p.add_argument(
-        "-t",
-        "--tool",
-        nargs="+",
-        default=["clang-format", "clang-tidy"],
-        metavar="TOOL",
-        help="Specify which tool(s) to install.",
+        "--backend",
+        choices=("auto", "binary", "wheel"),
+        default="auto",
+        help="Installation backend: auto (default, binary\u2192wheel), binary, or wheel",
     )
     install_p.add_argument(
         "-d",
@@ -273,16 +232,19 @@ def get_parser() -> argparse.ArgumentParser:
         help="Do not display a progress bar for downloads.",
     )
 
-    # --- ``clang-tools uninstall <version>`` ------------------------------
+    # --- ``clang-tools uninstall <tool> [<tool> ...] --version VER`` ----
     uninstall_p = subparsers.add_parser("uninstall", help="Uninstall clang-tools")
-    uninstall_p.add_argument("version", help="Version to uninstall")
     uninstall_p.add_argument(
-        "-t",
-        "--tool",
+        "tools",
         nargs="+",
-        default=["clang-format", "clang-tidy"],
         metavar="TOOL",
-        help="Specify which tool(s) to uninstall.",
+        help="Tool name(s) to uninstall (e.g. clang-format clang-tidy)",
+    )
+    uninstall_p.add_argument(
+        "--version",
+        required=True,
+        metavar="VER",
+        help="Version to uninstall (e.g. 18)",
     )
     uninstall_p.add_argument(
         "-d",
@@ -293,6 +255,11 @@ def get_parser() -> argparse.ArgumentParser:
     )
 
     return parser
+
+
+# ---------------------------------------------------------------------------
+#  Entry point
+# ---------------------------------------------------------------------------
 
 
 def main() -> int:
@@ -312,12 +279,12 @@ def main() -> int:
         parser.print_help()
         return 0
 
-    if args.command == "uninstall":
-        uninstall_clang_tools(args.tool, args.version, args.directory)
-        return 0
-
     if args.command == "install":
         return _handle_install(args)
+
+    if args.command == "uninstall":
+        uninstall_clang_tools(args.tools, args.version, args.directory)
+        return 0
 
     return 0  # unreachable
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -37,4 +37,4 @@ Python wheel installation module (integrated into unified CLI).
 [:octicons-code-16: View source](https://github.com/cpp-linter/clang-tools-pip/blob/main/clang_tools/wheel.py)
 
 Provides wheel-based installation via `cpp-linter-hooks`. Now
-accessible through the unified `clang-tools install --wheel` command.
+accessible through the unified `clang-tools install` command with `--backend wheel`.

--- a/docs/api.md
+++ b/docs/api.md
@@ -37,4 +37,4 @@ Python wheel installation module (integrated into unified CLI).
 [:octicons-code-16: View source](https://github.com/cpp-linter/clang-tools-pip/blob/main/clang_tools/wheel.py)
 
 Provides wheel-based installation via `cpp-linter-hooks`. Now
-accessible through the unified `clang-tools install` command with `--backend wheel`.
+accessible through the unified `clang-tools install` command.

--- a/docs/cli_args.md
+++ b/docs/cli_args.md
@@ -15,8 +15,7 @@ title: clang-tools CLI
 ## `clang-tools install`
 
 ```text
-    clang-tools install [-h] [--version VER]
-                           [--backend {auto,binary,wheel}] [-d DIR] [-f] [-b]
+    clang-tools install [-h] [--version VER] [-d DIR] [-f] [-b]
                            TOOL [TOOL ...]
 
 ```
@@ -25,13 +24,7 @@ title: clang-tools CLI
 
 :material-tag-outline: **v2.0.0**
 
-Version to install (e.g. 18). Required for --backend binary.
-
-### `--backend`
-
-:material-tag-outline: **v2.0.0** &nbsp; Default: `auto`
-
-Installation backend: auto (default, binary→wheel), binary, or wheel
+Version to install (e.g. 18). When specified, binary install is tried first, falling back to wheel.
 
 ### `-d, --directory`
 

--- a/docs/cli_args.md
+++ b/docs/cli_args.md
@@ -71,4 +71,3 @@ Version to uninstall (e.g. 18)
 :material-tag-outline: **v0.2.0** &nbsp; Default: ``
 
 The directory from which to uninstall the tools.
-

--- a/docs/cli_args.md
+++ b/docs/cli_args.md
@@ -15,35 +15,23 @@ title: clang-tools CLI
 ## `clang-tools install`
 
 ```text
-    clang-tools install [-h] [--binary] [--wheel] [--version VER]
-                           [-t TOOL [TOOL ...]] [-d DIR] [-f] [-b]
-                           target
+    clang-tools install [-h] [--version VER]
+                           [--backend {auto,binary,wheel}] [-d DIR] [-f] [-b]
+                           TOOL [TOOL ...]
 
 ```
 
-### `--binary`
-
-:material-tag-outline: **v1.0.0** &nbsp; Default: `False` &nbsp; Accepts no value
-
-Force binary (static build) installation
-
-### `--wheel`
-
-:material-tag-outline: **v1.0.0** &nbsp; Default: `False` &nbsp; Accepts no value
-
-Force wheel installation (resolves versions from PyPI)
-
 ### `--version`
 
-:material-tag-outline: **v1.0.0**
+:material-tag-outline: **v2.0.0**
 
-Explicit version for wheel install (when target is a tool name)
+Version to install (e.g. 18). Required for --backend binary.
 
-### `-t, --tool`
+### `--backend`
 
-:material-tag-outline: **v0.11.0** &nbsp; Default: `clang-format clang-tidy`
+:material-tag-outline: **v2.0.0** &nbsp; Default: `auto`
 
-Specify which tool(s) to install.
+Installation backend: auto (default, binary→wheel), binary, or wheel
 
 ### `-d, --directory`
 
@@ -68,18 +56,19 @@ Do not display a progress bar for downloads.
 ## `clang-tools uninstall`
 
 ```text
-    clang-tools uninstall [-h] [-t TOOL [TOOL ...]] [-d DIR] version
+    clang-tools uninstall [-h] --version VER [-d DIR] TOOL [TOOL ...]
 
 ```
 
-### `-t, --tool`
+### `--version`
 
-:material-tag-outline: **v0.11.0** &nbsp; Default: `clang-format clang-tidy`
+:material-tag-outline: **v0.1.0**
 
-Specify which tool(s) to uninstall.
+Version to uninstall (e.g. 18)
 
 ### `-d, --directory`
 
 :material-tag-outline: **v0.2.0** &nbsp; Default: ``
 
 The directory from which to uninstall the tools.
+

--- a/docs/gen_cli_docs.py
+++ b/docs/gen_cli_docs.py
@@ -14,7 +14,7 @@ REQUIRED_VERSIONS = {
     "0.2.0": ["directory"],
     "0.3.0": ["overwrite"],
     "0.5.0": ["no_progress_bar"],
-    "2.0.0": ["tools", "explicit_version", "backend"],
+    "2.0.0": ["tools", "explicit_version"],
 }
 
 

--- a/docs/gen_cli_docs.py
+++ b/docs/gen_cli_docs.py
@@ -10,12 +10,11 @@ import mkdocs_gen_files
 from clang_tools.main import get_parser
 
 REQUIRED_VERSIONS = {
-    "0.1.0": ["command", "target", "version"],
+    "0.1.0": ["command", "version"],
     "0.2.0": ["directory"],
     "0.3.0": ["overwrite"],
     "0.5.0": ["no_progress_bar"],
-    "0.11.0": ["tool"],
-    "1.0.0": ["binary", "wheel", "explicit_version"],
+    "2.0.0": ["tools", "explicit_version", "backend"],
 }
 
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -113,14 +113,10 @@ Python wheels using the unified `clang-tools` command.
 
     ```bash
     # Install latest clang-format wheel
-    clang-tools install clang-format --backend wheel
-    # Install specific version clang-format wheel
-    clang-tools install clang-format --version 21 --backend wheel
+    clang-tools install clang-format --version 21
 
     # Install latest clang-tidy wheel
-    clang-tools install clang-tidy --backend wheel
-    # Install specific version clang-tidy wheel
-    clang-tools install clang-tidy --version 21 --backend wheel
+    clang-tools install clang-tidy --version 21
     ```
 
 ## Supported Versions

--- a/docs/index.md
+++ b/docs/index.md
@@ -73,18 +73,20 @@ For a list of supported Command Line Interface options, see:
 
 ### Install binaries examples
 
-Use `clang-tools` command to install version 13 binaries:
+Use `clang-tools` to install tools. Positional arguments are always
+tool names; version is specified via `--version`:
 
-    clang-tools install 13
+    # Install latest clang-format (auto-detect: tries binary with --version, else wheel)
+    clang-tools install clang-format
 
-Or install to a specified directory:
+    # Install specific version (auto-detect: binary first, fall back to wheel)
+    clang-tools install clang-format --version 13
 
-    clang-tools install 13 --directory .
+    # Install to a specified directory
+    clang-tools install clang-format --version 13 --directory .
 
-Or install a specified tool, such as `clang-format` and
-`clang-query` version 14:
-
-    clang-tools install 14 --tool clang-format clang-query
+    # Install multiple tools
+    clang-tools install clang-format clang-tidy --version 14
 
 If the installed directory is in your path, you can run the installed tools:
 
@@ -111,14 +113,14 @@ Python wheels using the unified `clang-tools` command.
 
     ```bash
     # Install latest clang-format wheel
-    clang-tools install clang-format --wheel
+    clang-tools install clang-format --backend wheel
     # Install specific version clang-format wheel
-    clang-tools install clang-format --wheel --version 21
+    clang-tools install clang-format --version 21 --backend wheel
 
     # Install latest clang-tidy wheel
-    clang-tools install clang-tidy --wheel
+    clang-tools install clang-tidy --backend wheel
     # Install specific version clang-tidy wheel
-    clang-tools install clang-tidy --wheel --version 21
+    clang-tools install clang-tidy --version 21 --backend wheel
     ```
 
 ## Supported Versions

--- a/docs/index.md
+++ b/docs/index.md
@@ -106,10 +106,9 @@ After installing the `clang-tools` CLI, you can install the
 Python wheels using the unified `clang-tools` command.
 
 !!! important
-    Wheel installation is primarily intended for
-    cpp-linter projects to simplify installing clang tools Python wheels.
-    For general use, it is recommended to install the wheels directly
-    using `pip`, `pipx`, `uv`, or similar tools.
+    Wheel installation resolves the latest matching version from PyPI
+    (e.g. `--version 18` finds `18.1.8`). If you know the exact version,
+    `pip install <tool>==<version>` is equivalent and more direct.
 
     ```bash
     # Install latest clang-format wheel

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -328,6 +328,112 @@ def test_main_install_auto_detect_new_wheel_tools(
     ]
 
 
+def test_main_install_auto_detect_tool_name_with_version(
+    monkeypatch: pytest.MonkeyPatch, capsys, tmp_path
+):
+    """Auto-detect: tool name + --version tries binary first (succeeds)."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "clang-tools",
+            "install",
+            "clang-format",
+            "--version",
+            "12",
+            "--directory",
+            str(tmp_path),
+            "--no-progress-bar",
+        ],
+    )
+    exit_code = main()
+    assert exit_code == 0
+    bin_path = tmp_path / f"clang-format-12{suffix}"
+    assert bin_path.exists()
+
+
+def test_main_install_auto_detect_tool_name_with_version_fallback(
+    monkeypatch: pytest.MonkeyPatch, capsys, tmp_path
+):
+    """Auto-detect: tool name + --version falls back to wheel when binary fails."""
+    monkeypatch.setattr("clang_tools.install.binary_repo", "not-a-valid-url")
+    monkeypatch.setattr(
+        "clang_tools.main._wheel_install",
+        lambda tools, ver: 0,
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "clang-tools",
+            "install",
+            "clang-tidy",
+            "--version",
+            "12",
+            "--no-progress-bar",
+        ],
+    )
+    exit_code = main()
+    result = capsys.readouterr()
+    assert exit_code == 0
+    assert "falling back to wheel" in result.err
+
+
+def test_main_install_auto_detect_tool_name_with_version_out_of_range(
+    monkeypatch: pytest.MonkeyPatch, capsys
+):
+    """Auto-detect: tool name + --version with out-of-range version falls back to wheel."""
+    tracked: list = []
+
+    def mock_wheel(tools, version):
+        tracked.append((tools, version))
+        return 0
+
+    monkeypatch.setattr("clang_tools.main._wheel_install", mock_wheel)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "clang-tools",
+            "install",
+            "clang-format",
+            "--version",
+            "99",
+        ],
+    )
+    exit_code = main()
+    assert exit_code == 0
+    assert tracked == [(["clang-format"], "99")]
+
+
+def test_main_install_auto_detect_tool_name_with_version_bad_semver(
+    monkeypatch: pytest.MonkeyPatch, capsys
+):
+    """Auto-detect: tool name + --version with 0.0.0 falls back to wheel."""
+    tracked: list = []
+
+    def mock_wheel(tools, version):
+        tracked.append((tools, version))
+        return 0
+
+    monkeypatch.setattr("clang_tools.main._wheel_install", mock_wheel)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "clang-tools",
+            "install",
+            "clang-tidy",
+            "--version",
+            "0.0.0",
+        ],
+    )
+    exit_code = main()
+    assert exit_code == 0
+    assert tracked == [(["clang-tidy"], "0.0.0")]
+
+
 def test_main_install_wheel_failure(monkeypatch: pytest.MonkeyPatch, capsys):
     """``--wheel`` with a failing _wheel_install returns 1."""
     monkeypatch.setattr("clang_tools.main._wheel_install", lambda tools, ver: 1)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -66,16 +66,21 @@ def test_install_subcommand_directory(parser: ArgumentParser):
 
 def test_install_subcommand_flags(parser: ArgumentParser):
     args = parser.parse_args(
-        ["install", "clang-format", "--version", "18", "--overwrite", "--no-progress-bar"]
+        [
+            "install",
+            "clang-format",
+            "--version",
+            "18",
+            "--overwrite",
+            "--no-progress-bar",
+        ]
     )
     assert args.overwrite is True
     assert args.no_progress_bar is True
 
 
 def test_uninstall_subcommand(parser: ArgumentParser):
-    args = parser.parse_args(
-        ["uninstall", "clang-format", "--version", "12"]
-    )
+    args = parser.parse_args(["uninstall", "clang-format", "--version", "12"])
     assert args.command == "uninstall"
     assert args.tools == ["clang-format"]
     assert args.version == "12"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -4,27 +4,7 @@ import sys
 from argparse import ArgumentParser
 import pytest
 from clang_tools import suffix
-from clang_tools.main import get_parser, main, _is_version_like
-
-
-# ---------------------------------------------------------------------------
-#  _is_version_like helper
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.parametrize(
-    "target,expected",
-    [
-        ("18", True),
-        ("18.1", True),
-        ("18.1.0", True),
-        ("clang-format", False),
-        ("clang-tidy", False),
-        ("abc", False),
-    ],
-)
-def test_is_version_like(target: str, expected: bool):
-    assert _is_version_like(target) is expected
+from clang_tools.main import get_parser, main
 
 
 # ---------------------------------------------------------------------------
@@ -39,69 +19,78 @@ def parser() -> ArgumentParser:
 
 def test_install_subcommand_defaults(parser: ArgumentParser):
     """Default values for the ``install`` subcommand."""
-    args = parser.parse_args(["install", "18"])
+    args = parser.parse_args(["install", "clang-format"])
     assert args.command == "install"
-    assert args.target == "18"
-    assert args.binary is False
-    assert args.wheel is False
-    assert args.tool == ["clang-format", "clang-tidy"]
+    assert args.tools == ["clang-format"]
+    assert args.backend == "auto"
+    assert args.explicit_version is None
     assert args.directory == ""
     assert args.overwrite is False
     assert args.no_progress_bar is False
 
 
-def test_install_subcommand_binary(parser: ArgumentParser):
-    args = parser.parse_args(["install", "18", "--binary"])
-    assert args.binary is True
-    assert args.wheel is False
+def test_install_subcommand_multiple_tools(parser: ArgumentParser):
+    args = parser.parse_args(["install", "clang-format", "clang-tidy"])
+    assert args.tools == ["clang-format", "clang-tidy"]
 
 
-def test_install_subcommand_wheel(parser: ArgumentParser):
-    args = parser.parse_args(["install", "clang-format", "--wheel"])
-    assert args.wheel is True
-    assert args.binary is False
+def test_install_subcommand_backend_binary(parser: ArgumentParser):
+    args = parser.parse_args(
+        ["install", "clang-format", "--version", "18", "--backend", "binary"]
+    )
+    assert args.backend == "binary"
+    assert args.explicit_version == "18"
+
+
+def test_install_subcommand_backend_wheel(parser: ArgumentParser):
+    args = parser.parse_args(["install", "clang-format", "--backend", "wheel"])
+    assert args.backend == "wheel"
+    assert args.explicit_version is None
 
 
 def test_install_subcommand_wheel_with_version(parser: ArgumentParser):
     args = parser.parse_args(
-        ["install", "clang-format", "--wheel", "--version", "15.0.7"]
+        ["install", "clang-format", "--backend", "wheel", "--version", "15.0.7"]
     )
-    assert args.wheel is True
-    assert args.target == "clang-format"
+    assert args.backend == "wheel"
+    assert args.tools == ["clang-format"]
     assert args.explicit_version == "15.0.7"
 
 
-def test_install_subcommand_custom_tools(parser: ArgumentParser):
-    args = parser.parse_args(["install", "18", "-t", "clang-tidy"])
-    assert args.tool == ["clang-tidy"]
-
-
 def test_install_subcommand_directory(parser: ArgumentParser):
-    args = parser.parse_args(["install", "18", "-d", "/custom/path"])
+    args = parser.parse_args(
+        ["install", "clang-format", "--version", "18", "-d", "/custom/path"]
+    )
     assert args.directory == "/custom/path"
 
 
 def test_install_subcommand_flags(parser: ArgumentParser):
-    args = parser.parse_args(["install", "18", "--overwrite", "--no-progress-bar"])
+    args = parser.parse_args(
+        ["install", "clang-format", "--version", "18", "--overwrite", "--no-progress-bar"]
+    )
     assert args.overwrite is True
     assert args.no_progress_bar is True
 
 
 def test_uninstall_subcommand(parser: ArgumentParser):
-    args = parser.parse_args(["uninstall", "12", "-t", "clang-format"])
+    args = parser.parse_args(
+        ["uninstall", "clang-format", "--version", "12"]
+    )
     assert args.command == "uninstall"
+    assert args.tools == ["clang-format"]
     assert args.version == "12"
-    assert args.tool == ["clang-format"]
-
-
-def test_uninstall_subcommand_defaults(parser: ArgumentParser):
-    args = parser.parse_args(["uninstall", "12"])
-    assert args.tool == ["clang-format", "clang-tidy"]
     assert args.directory == ""
 
 
+def test_uninstall_subcommand_multiple_tools(parser: ArgumentParser):
+    args = parser.parse_args(
+        ["uninstall", "clang-format", "clang-tidy", "--version", "12"]
+    )
+    assert args.tools == ["clang-format", "clang-tidy"]
+
+
 # ---------------------------------------------------------------------------
-#  Integration / functional tests
+#  Integration / functional tests – ``install`` subcommand
 # ---------------------------------------------------------------------------
 
 
@@ -114,66 +103,8 @@ def test_main_no_args(monkeypatch: pytest.MonkeyPatch, capsys):
     assert exit_code == 0
 
 
-# ---- ``install`` subcommand -------------------------------------------
-
-
-def test_main_install_binary(monkeypatch: pytest.MonkeyPatch, tmp_path):
-    """``clang-tools install 12 --binary`` installs binary."""
-    monkeypatch.chdir(tmp_path)
-    monkeypatch.setattr(
-        sys,
-        "argv",
-        [
-            "clang-tools",
-            "install",
-            "12",
-            "--binary",
-            "--tool",
-            "clang-format",
-            "--directory",
-            str(tmp_path),
-            "--no-progress-bar",
-        ],
-    )
-    exit_code = main()
-    assert exit_code == 0
-    bin_path = tmp_path / f"clang-format-12{suffix}"
-    assert bin_path.exists()
-
-
-def test_main_install_binary_requires_version(monkeypatch: pytest.MonkeyPatch, capsys):
-    """``--binary`` with a non-version target is an error."""
-    monkeypatch.setattr(
-        sys,
-        "argv",
-        ["clang-tools", "install", "clang-format", "--binary"],
-    )
-    exit_code = main()
-    result = capsys.readouterr()
-    assert "requires a version number" in result.err
-    assert exit_code == 1
-
-
-def test_main_install_binary_invalid_version(monkeypatch: pytest.MonkeyPatch, capsys):
-    """``--binary`` with a non-version target shows error."""
-    monkeypatch.setattr(
-        sys,
-        "argv",
-        ["clang-tools", "install", "not-a-version", "--binary"],
-    )
-    exit_code = main()
-    result = capsys.readouterr()
-    assert "requires a version number" in result.err
-    assert exit_code == 1
-
-
-def test_main_install_binary_tool_as_positional_with_version(
-    monkeypatch: pytest.MonkeyPatch, tmp_path
-):
-    """
-    ``--binary`` accepts tool name as positional with ``--version``
-    (consistent with ``--wheel``).
-    """
+def test_main_install_backend_binary(monkeypatch: pytest.MonkeyPatch, tmp_path):
+    """``clang-tools install clang-format --version 12 --backend binary``."""
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(
         sys,
@@ -184,7 +115,8 @@ def test_main_install_binary_tool_as_positional_with_version(
             "clang-format",
             "--version",
             "12",
-            "--binary",
+            "--backend",
+            "binary",
             "--directory",
             str(tmp_path),
             "--no-progress-bar",
@@ -196,13 +128,25 @@ def test_main_install_binary_tool_as_positional_with_version(
     assert bin_path.exists()
 
 
-def test_main_install_binary_tool_as_positional_bad_semver(
+def test_main_install_backend_binary_requires_version(
     monkeypatch: pytest.MonkeyPatch, capsys
 ):
-    """
-    ``--binary`` with tool name as positional and a zeroed-out ``--version``
-    (e.g. 0.0.0) shows the semantic-version error.
-    """
+    """``--backend binary`` without ``--version`` is an error."""
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["clang-tools", "install", "clang-format", "--backend", "binary"],
+    )
+    exit_code = main()
+    result = capsys.readouterr()
+    assert "requires --version" in result.err
+    assert exit_code == 1
+
+
+def test_main_install_backend_binary_bad_semver(
+    monkeypatch: pytest.MonkeyPatch, capsys
+):
+    """``--backend binary`` with a zeroed-out version (e.g. 0.0.0) shows the semantic-version error."""
     monkeypatch.setattr(
         sys,
         "argv",
@@ -212,7 +156,8 @@ def test_main_install_binary_tool_as_positional_bad_semver(
             "clang-tidy",
             "--version",
             "0.0.0",
-            "--binary",
+            "--backend",
+            "binary",
         ],
     )
     exit_code = main()
@@ -221,21 +166,8 @@ def test_main_install_binary_tool_as_positional_bad_semver(
     assert exit_code == 1
 
 
-def test_main_install_binary_and_wheel_mutex(monkeypatch: pytest.MonkeyPatch, capsys):
-    """``--binary`` and ``--wheel`` together is an error."""
-    monkeypatch.setattr(
-        sys,
-        "argv",
-        ["clang-tools", "install", "18", "--binary", "--wheel"],
-    )
-    exit_code = main()
-    result = capsys.readouterr()
-    assert "mutually exclusive" in result.err
-    assert exit_code == 1
-
-
-def test_main_install_wheel_success(monkeypatch: pytest.MonkeyPatch, capsys):
-    """``--wheel`` with a tool name succeeds via mocked _wheel_install."""
+def test_main_install_backend_wheel_success(monkeypatch: pytest.MonkeyPatch, capsys):
+    """``--backend wheel`` with a tool name succeeds via mocked _wheel_install."""
     monkeypatch.setattr(
         "clang_tools.main._wheel_install",
         lambda tools, ver: 0,
@@ -243,7 +175,7 @@ def test_main_install_wheel_success(monkeypatch: pytest.MonkeyPatch, capsys):
     monkeypatch.setattr(
         sys,
         "argv",
-        ["clang-tools", "install", "clang-format", "--wheel"],
+        ["clang-tools", "install", "clang-format", "--backend", "wheel"],
     )
     exit_code = main()
     result = capsys.readouterr()
@@ -251,12 +183,14 @@ def test_main_install_wheel_success(monkeypatch: pytest.MonkeyPatch, capsys):
     assert result.err == ""
 
 
-def test_main_install_wheel_unsupported_tool(monkeypatch: pytest.MonkeyPatch, capsys):
-    """``--wheel`` with a binary-only tool name shows error."""
+def test_main_install_backend_wheel_unsupported_tool(
+    monkeypatch: pytest.MonkeyPatch, capsys
+):
+    """``--backend wheel`` with a binary-only tool name shows error."""
     monkeypatch.setattr(
         sys,
         "argv",
-        ["clang-tools", "install", "clang-query", "--wheel"],
+        ["clang-tools", "install", "clang-query", "--backend", "wheel"],
     )
     exit_code = main()
     result = capsys.readouterr()
@@ -264,43 +198,86 @@ def test_main_install_wheel_unsupported_tool(monkeypatch: pytest.MonkeyPatch, ca
     assert exit_code == 1
 
 
-def test_main_install_wheel_include_cleaner(monkeypatch: pytest.MonkeyPatch, capsys):
-    """``--wheel`` with clang-include-cleaner succeeds via mocked _wheel_install."""
-    monkeypatch.setattr(
-        "clang_tools.main._wheel_install",
-        lambda tools, ver: 0,
-    )
-    monkeypatch.setattr(
-        sys,
-        "argv",
-        ["clang-tools", "install", "clang-include-cleaner", "--wheel"],
-    )
-    exit_code = main()
-    result = capsys.readouterr()
-    assert exit_code == 0
-    assert result.err == ""
-
-
-def test_main_install_wheel_apply_replacements(monkeypatch: pytest.MonkeyPatch, capsys):
-    """``--wheel`` with clang-apply-replacements succeeds via mocked _wheel_install."""
-    monkeypatch.setattr(
-        "clang_tools.main._wheel_install",
-        lambda tools, ver: 0,
-    )
-    monkeypatch.setattr(
-        sys,
-        "argv",
-        ["clang-tools", "install", "clang-apply-replacements", "--wheel"],
-    )
-    exit_code = main()
-    result = capsys.readouterr()
-    assert exit_code == 0
-    assert result.err == ""
-
-
-def test_main_install_auto_detect_new_wheel_tools(
+def test_main_install_backend_wheel_include_cleaner(
     monkeypatch: pytest.MonkeyPatch, capsys
 ):
+    """``--backend wheel`` with clang-include-cleaner succeeds."""
+    monkeypatch.setattr(
+        "clang_tools.main._wheel_install",
+        lambda tools, ver: 0,
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["clang-tools", "install", "clang-include-cleaner", "--backend", "wheel"],
+    )
+    exit_code = main()
+    result = capsys.readouterr()
+    assert exit_code == 0
+    assert result.err == ""
+
+
+def test_main_install_backend_wheel_failure(monkeypatch: pytest.MonkeyPatch, capsys):
+    """``--backend wheel`` with a failing _wheel_install returns 1."""
+    monkeypatch.setattr("clang_tools.main._wheel_install", lambda tools, ver: 1)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["clang-tools", "install", "clang-format", "--backend", "wheel"],
+    )
+    exit_code = main()
+    assert exit_code == 1
+
+
+def test_main_install_backend_wheel_version_arg(
+    monkeypatch: pytest.MonkeyPatch, capsys
+):
+    """``--backend wheel`` with ``--version`` passes version to _wheel_install."""
+    tracked_version = []
+
+    def mock_wheel(tools, version):
+        tracked_version.append((tools, version))
+        return 0
+
+    monkeypatch.setattr("clang_tools.main._wheel_install", mock_wheel)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "clang-tools",
+            "install",
+            "clang-format",
+            "--backend",
+            "wheel",
+            "--version",
+            "15.0.7",
+        ],
+    )
+    exit_code = main()
+    assert exit_code == 0
+    assert tracked_version == [(["clang-format"], "15.0.7")]
+
+
+def test_main_install_auto_no_version(monkeypatch: pytest.MonkeyPatch, capsys):
+    """Auto-detect without --version goes to wheel install."""
+    tracked_install: list = []
+
+    def mock_wheel(tools, version):
+        tracked_install.append((tools, version))
+        return 0
+
+    monkeypatch.setattr("clang_tools.main._wheel_install", mock_wheel)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["clang-tools", "install", "clang-tidy"],
+    )
+    exit_code = main()
+    assert exit_code == 0
+    assert tracked_install == [(["clang-tidy"], None)]
+
+
+def test_main_install_auto_new_wheel_tools(monkeypatch: pytest.MonkeyPatch, capsys):
     """Auto-detect treats clang-include-cleaner / clang-apply-replacements as wheel."""
     tracked = []
 
@@ -310,13 +287,11 @@ def test_main_install_auto_detect_new_wheel_tools(
 
     monkeypatch.setattr("clang_tools.main._wheel_install", mock_wheel)
 
-    # Test clang-include-cleaner
     monkeypatch.setattr(
         sys, "argv", ["clang-tools", "install", "clang-include-cleaner"]
     )
     assert main() == 0
 
-    # Test clang-apply-replacements
     monkeypatch.setattr(
         sys, "argv", ["clang-tools", "install", "clang-apply-replacements"]
     )
@@ -328,7 +303,7 @@ def test_main_install_auto_detect_new_wheel_tools(
     ]
 
 
-def test_main_install_auto_detect_tool_name_with_version(
+def test_main_install_auto_with_version_success(
     monkeypatch: pytest.MonkeyPatch, capsys, tmp_path
 ):
     """Auto-detect: tool name + --version tries binary first (succeeds)."""
@@ -353,7 +328,7 @@ def test_main_install_auto_detect_tool_name_with_version(
     assert bin_path.exists()
 
 
-def test_main_install_auto_detect_tool_name_with_version_fallback(
+def test_main_install_auto_with_version_fallback(
     monkeypatch: pytest.MonkeyPatch, capsys, tmp_path
 ):
     """Auto-detect: tool name + --version falls back to wheel when binary fails."""
@@ -380,10 +355,10 @@ def test_main_install_auto_detect_tool_name_with_version_fallback(
     assert "falling back to wheel" in result.err
 
 
-def test_main_install_auto_detect_tool_name_with_version_out_of_range(
+def test_main_install_auto_with_version_out_of_range(
     monkeypatch: pytest.MonkeyPatch, capsys
 ):
-    """Auto-detect: tool name + --version with out-of-range version falls back to wheel."""
+    """Auto-detect: tool + --version with out-of-range version falls back to wheel."""
     tracked: list = []
 
     def mock_wheel(tools, version):
@@ -407,10 +382,10 @@ def test_main_install_auto_detect_tool_name_with_version_out_of_range(
     assert tracked == [(["clang-format"], "99")]
 
 
-def test_main_install_auto_detect_tool_name_with_version_bad_semver(
+def test_main_install_auto_with_version_bad_semver(
     monkeypatch: pytest.MonkeyPatch, capsys
 ):
-    """Auto-detect: tool name + --version with 0.0.0 falls back to wheel."""
+    """Auto-detect: tool + --version with 0.0.0 falls back to wheel."""
     tracked: list = []
 
     def mock_wheel(tools, version):
@@ -434,67 +409,23 @@ def test_main_install_auto_detect_tool_name_with_version_bad_semver(
     assert tracked == [(["clang-tidy"], "0.0.0")]
 
 
-def test_main_install_wheel_failure(monkeypatch: pytest.MonkeyPatch, capsys):
-    """``--wheel`` with a failing _wheel_install returns 1."""
-    monkeypatch.setattr("clang_tools.main._wheel_install", lambda tools, ver: 1)
+def test_main_install_auto_unsupported_tool(monkeypatch: pytest.MonkeyPatch, capsys):
+    """Auto-detect with a binary-only tool name shows error."""
     monkeypatch.setattr(
         sys,
         "argv",
-        ["clang-tools", "install", "clang-format", "--wheel"],
+        ["clang-tools", "install", "clang-query"],
     )
     exit_code = main()
+    result = capsys.readouterr()
+    assert "Unknown tool" in result.err
     assert exit_code == 1
 
 
-def test_main_install_wheel_version_arg(monkeypatch: pytest.MonkeyPatch, capsys):
-    """``--wheel`` with ``--version`` passes version to _wheel_install."""
-    tracked_version = []
-
-    def mock_wheel(tools, version):
-        tracked_version.append((tools, version))
-        return 0
-
-    monkeypatch.setattr("clang_tools.main._wheel_install", mock_wheel)
-    monkeypatch.setattr(
-        sys,
-        "argv",
-        [
-            "clang-tools",
-            "install",
-            "clang-format",
-            "--wheel",
-            "--version",
-            "15.0.7",
-        ],
-    )
-    exit_code = main()
-    assert exit_code == 0
-    assert tracked_version == [(["clang-format"], "15.0.7")]
-
-
-def test_main_install_wheel_with_version_as_target(
-    monkeypatch: pytest.MonkeyPatch, capsys
+def test_main_install_auto_multiple_tools(
+    monkeypatch: pytest.MonkeyPatch, capsys, tmp_path
 ):
-    """``clang-tools install 18 --wheel`` uses version as target, tool from -t."""
-    tracked: list = []
-
-    def mock_wheel(tools, version):
-        tracked.append((tools, version))
-        return 0
-
-    monkeypatch.setattr("clang_tools.main._wheel_install", mock_wheel)
-    monkeypatch.setattr(
-        sys,
-        "argv",
-        ["clang-tools", "install", "18", "--wheel", "-t", "clang-tidy"],
-    )
-    exit_code = main()
-    assert exit_code == 0
-    assert tracked == [(["clang-tidy"], "18")]
-
-
-def test_main_install_auto_detect_binary(monkeypatch: pytest.MonkeyPatch, tmp_path):
-    """Auto-detect installs binary for version in supported range."""
+    """Auto-detect: multiple tool names with --version."""
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(
         sys,
@@ -502,9 +433,10 @@ def test_main_install_auto_detect_binary(monkeypatch: pytest.MonkeyPatch, tmp_pa
         [
             "clang-tools",
             "install",
-            "12",
-            "--tool",
             "clang-format",
+            "clang-tidy",
+            "--version",
+            "12",
             "--directory",
             str(tmp_path),
             "--no-progress-bar",
@@ -512,91 +444,77 @@ def test_main_install_auto_detect_binary(monkeypatch: pytest.MonkeyPatch, tmp_pa
     )
     exit_code = main()
     assert exit_code == 0
-    bin_path = tmp_path / f"clang-format-12{suffix}"
-    assert bin_path.exists()
+    for tool in ("clang-format", "clang-tidy"):
+        bin_path = tmp_path / f"{tool}-12{suffix}"
+        assert bin_path.exists()
 
 
-def test_main_install_auto_detect_fallback(
-    monkeypatch: pytest.MonkeyPatch, tmp_path, capsys
-):
-    """Auto-detect falls back to wheel when binary fails."""
-    monkeypatch.setattr("clang_tools.install.binary_repo", "not-a-valid-url")
-    monkeypatch.setattr(
-        "clang_tools.main._wheel_install",
-        lambda tools, ver: 0,
-    )
+# ---- ``uninstall`` subcommand -----------------------------------------
+
+
+def test_main_uninstall_subcommand(monkeypatch: pytest.MonkeyPatch, tmp_path, capsys):
+    """``clang-tools uninstall clang-format --version 12`` removes installed tools."""
+    tool_name = "clang-format"
+    version = "12"
+    install_dir = str(tmp_path)
+    dummy_bin = tmp_path / f"{tool_name}-{version}{suffix}"
+    dummy_bin.write_bytes(b"dummy")
+
     monkeypatch.setattr(
         sys,
         "argv",
         [
             "clang-tools",
-            "install",
-            "12",
-            "--tool",
-            "clang-format",
-            "--no-progress-bar",
+            "uninstall",
+            tool_name,
+            "--version",
+            version,
+            "--directory",
+            install_dir,
         ],
     )
     exit_code = main()
     result = capsys.readouterr()
     assert exit_code == 0
-    assert "falling back to wheel" in result.err
+    assert "Uninstalling" in result.out
+    assert not dummy_bin.exists()
 
 
-def test_main_install_auto_detect_non_version(monkeypatch: pytest.MonkeyPatch, capsys):
-    """Auto-detect treats non-version target as tool name (wheel install)."""
-    tracked_install: list = []
-
-    def mock_wheel(tools, version):
-        tracked_install.append((tools, version))
-        return 0
-
-    monkeypatch.setattr("clang_tools.main._wheel_install", mock_wheel)
-    monkeypatch.setattr(
-        sys,
-        "argv",
-        ["clang-tools", "install", "clang-tidy"],
-    )
-    exit_code = main()
-    assert exit_code == 0
-    assert tracked_install == [(["clang-tidy"], None)]
-
-
-def test_main_install_auto_detect_out_of_range_version(
-    monkeypatch: pytest.MonkeyPatch, capsys
+def test_main_uninstall_multiple_tools(
+    monkeypatch: pytest.MonkeyPatch, tmp_path, capsys
 ):
-    """Auto-detect falls back to wheel for out-of-range versions."""
-    monkeypatch.setattr(
-        "clang_tools.main._wheel_install",
-        lambda tools, ver: 0,
-    )
+    """``clang-tools uninstall clang-format clang-tidy --version 12``."""
+    version = "12"
+    install_dir = str(tmp_path)
+    for tool in ("clang-format", "clang-tidy"):
+        dummy = tmp_path / f"{tool}-{version}{suffix}"
+        dummy.write_bytes(b"dummy")
+
     monkeypatch.setattr(
         sys,
         "argv",
-        ["clang-tools", "install", "99", "--tool", "clang-format"],
+        [
+            "clang-tools",
+            "uninstall",
+            "clang-format",
+            "clang-tidy",
+            "--version",
+            version,
+            "--directory",
+            install_dir,
+        ],
     )
     exit_code = main()
     result = capsys.readouterr()
     assert exit_code == 0
-    assert "falling back to wheel" in result.err
+    assert "Uninstalling" in result.out
+    for tool in ("clang-format", "clang-tidy"):
+        assert not (tmp_path / f"{tool}-{version}{suffix}").exists()
 
 
-def test_main_install_auto_detect_invalid_version(
-    monkeypatch: pytest.MonkeyPatch, capsys
-):
-    """Auto-detect with a non-version, non-tool target shows error."""
-    monkeypatch.setattr(
-        sys,
-        "argv",
-        ["clang-tools", "install", "abc.def"],
-    )
-    exit_code = main()
-    result = capsys.readouterr()
-    assert "Unknown target" in result.err
-    assert exit_code == 1
-
-
-# ---- ``uninstall`` subcommand -----------------------------------------
+# ---------------------------------------------------------------------------
+#  _wheel_install helper tests
+# ---------------------------------------------------------------------------
 
 
 def test_wheel_install_none_none_fallback(monkeypatch: pytest.MonkeyPatch, capsys):
@@ -636,52 +554,6 @@ def test_wheel_install_failure(monkeypatch: pytest.MonkeyPatch, capsys):
     assert "ERROR: resolve failed" in capsys.readouterr().err
 
 
-def test_main_install_binary_bad_semver(monkeypatch: pytest.MonkeyPatch, capsys):
-    """``--binary`` with a version-like but zeroed-out version (e.g. 0.0.0)."""
-    monkeypatch.setattr(
-        sys,
-        "argv",
-        ["clang-tools", "install", "0.0.0", "--binary"],
-    )
-    exit_code = main()
-    result = capsys.readouterr()
-    assert exit_code == 1
-    assert "not a semantic" in result.err
-
-
-def test_main_uninstall_subcommand(monkeypatch: pytest.MonkeyPatch, tmp_path, capsys):
-    """``clang-tools uninstall 12`` removes installed tools."""
-    tool_name = "clang-format"
-    version = "12"
-    install_dir = str(tmp_path)
-    dummy_bin = tmp_path / f"{tool_name}-{version}{suffix}"
-    dummy_bin.write_bytes(b"dummy")
-
-    monkeypatch.setattr(
-        sys,
-        "argv",
-        [
-            "clang-tools",
-            "uninstall",
-            version,
-            "--tool",
-            tool_name,
-            "--directory",
-            install_dir,
-        ],
-    )
-    exit_code = main()
-    result = capsys.readouterr()
-    assert exit_code == 0
-    assert "Uninstalling" in result.out
-    assert not dummy_bin.exists()
-
-
-# ---------------------------------------------------------------------------
-#  Additional _wheel_install coverage (version=None, multi-tool mix)
-# ---------------------------------------------------------------------------
-
-
 def test_wheel_install_latest_success(monkeypatch: pytest.MonkeyPatch, capsys):
     """Test _wheel_install with version=None ("latest version" path, success)."""
     from clang_tools.main import _wheel_install
@@ -715,8 +587,8 @@ def test_wheel_install_multiple_tools_mixed(monkeypatch: pytest.MonkeyPatch, cap
 
     def mock_resolve(tool, version):
         if tool == "clang-tidy":
-            return None, "TEST_ERROR: failed"  # fails with error
-        return f"/fake/{tool}", None  # succeeds
+            return None, "TEST_ERROR: failed"
+        return f"/fake/{tool}", None
 
     monkeypatch.setattr("clang_tools.wheel_install.resolve_wheel_install", mock_resolve)
     assert _wheel_install(["clang-format", "clang-tidy"], "18") == 1
@@ -726,18 +598,30 @@ def test_wheel_install_multiple_tools_mixed(monkeypatch: pytest.MonkeyPatch, cap
 
 
 # ---------------------------------------------------------------------------
-#  Additional _handle_auto_detect coverage (bad semver path)
+#  --backend binary fallback tests
 # ---------------------------------------------------------------------------
 
 
-def test_main_install_auto_detect_bad_semver(monkeypatch: pytest.MonkeyPatch, capsys):
-    """Auto-detect with a version that parses to (0,0,0) shows error."""
+def test_main_install_backend_binary_download_error(
+    monkeypatch: pytest.MonkeyPatch, capsys
+):
+    """``--backend binary`` that fails reports the error and returns 1."""
+    monkeypatch.setattr("clang_tools.install.binary_repo", "not-a-valid-url")
     monkeypatch.setattr(
         sys,
         "argv",
-        ["clang-tools", "install", "0.0.0"],
+        [
+            "clang-tools",
+            "install",
+            "clang-format",
+            "--version",
+            "12",
+            "--backend",
+            "binary",
+            "--no-progress-bar",
+        ],
     )
     exit_code = main()
     result = capsys.readouterr()
     assert exit_code == 1
-    assert "not a semantic" in result.err
+    assert "Binary install failed" in result.err

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -34,9 +34,7 @@ def test_install_subcommand_multiple_tools(parser: ArgumentParser):
 
 
 def test_install_subcommand_with_version(parser: ArgumentParser):
-    args = parser.parse_args(
-        ["install", "clang-format", "--version", "18"]
-    )
+    args = parser.parse_args(["install", "clang-format", "--version", "18"])
     assert args.explicit_version == "18"
 
 
@@ -189,9 +187,7 @@ def test_main_install_with_version_out_of_range(
     assert tracked == [(["clang-format"], "99")]
 
 
-def test_main_install_with_version_bad_semver(
-    monkeypatch: pytest.MonkeyPatch, capsys
-):
+def test_main_install_with_version_bad_semver(monkeypatch: pytest.MonkeyPatch, capsys):
     """Auto-detect with 0.0.0 falls back to wheel."""
     tracked: list = []
 
@@ -255,9 +251,7 @@ def test_main_install_unsupported_tool(monkeypatch: pytest.MonkeyPatch, capsys):
     assert exit_code == 1
 
 
-def test_main_install_multiple_tools(
-    monkeypatch: pytest.MonkeyPatch, capsys, tmp_path
-):
+def test_main_install_multiple_tools(monkeypatch: pytest.MonkeyPatch, capsys, tmp_path):
     """Auto-detect: multiple tool names with --version."""
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -22,7 +22,6 @@ def test_install_subcommand_defaults(parser: ArgumentParser):
     args = parser.parse_args(["install", "clang-format"])
     assert args.command == "install"
     assert args.tools == ["clang-format"]
-    assert args.backend == "auto"
     assert args.explicit_version is None
     assert args.directory == ""
     assert args.overwrite is False
@@ -34,27 +33,11 @@ def test_install_subcommand_multiple_tools(parser: ArgumentParser):
     assert args.tools == ["clang-format", "clang-tidy"]
 
 
-def test_install_subcommand_backend_binary(parser: ArgumentParser):
+def test_install_subcommand_with_version(parser: ArgumentParser):
     args = parser.parse_args(
-        ["install", "clang-format", "--version", "18", "--backend", "binary"]
+        ["install", "clang-format", "--version", "18"]
     )
-    assert args.backend == "binary"
     assert args.explicit_version == "18"
-
-
-def test_install_subcommand_backend_wheel(parser: ArgumentParser):
-    args = parser.parse_args(["install", "clang-format", "--backend", "wheel"])
-    assert args.backend == "wheel"
-    assert args.explicit_version is None
-
-
-def test_install_subcommand_wheel_with_version(parser: ArgumentParser):
-    args = parser.parse_args(
-        ["install", "clang-format", "--backend", "wheel", "--version", "15.0.7"]
-    )
-    assert args.backend == "wheel"
-    assert args.tools == ["clang-format"]
-    assert args.explicit_version == "15.0.7"
 
 
 def test_install_subcommand_directory(parser: ArgumentParser):
@@ -108,162 +91,7 @@ def test_main_no_args(monkeypatch: pytest.MonkeyPatch, capsys):
     assert exit_code == 0
 
 
-def test_main_install_backend_binary(monkeypatch: pytest.MonkeyPatch, tmp_path):
-    """``clang-tools install clang-format --version 12 --backend binary``."""
-    monkeypatch.chdir(tmp_path)
-    monkeypatch.setattr(
-        sys,
-        "argv",
-        [
-            "clang-tools",
-            "install",
-            "clang-format",
-            "--version",
-            "12",
-            "--backend",
-            "binary",
-            "--directory",
-            str(tmp_path),
-            "--no-progress-bar",
-        ],
-    )
-    exit_code = main()
-    assert exit_code == 0
-    bin_path = tmp_path / f"clang-format-12{suffix}"
-    assert bin_path.exists()
-
-
-def test_main_install_backend_binary_requires_version(
-    monkeypatch: pytest.MonkeyPatch, capsys
-):
-    """``--backend binary`` without ``--version`` is an error."""
-    monkeypatch.setattr(
-        sys,
-        "argv",
-        ["clang-tools", "install", "clang-format", "--backend", "binary"],
-    )
-    exit_code = main()
-    result = capsys.readouterr()
-    assert "requires --version" in result.err
-    assert exit_code == 1
-
-
-def test_main_install_backend_binary_bad_semver(
-    monkeypatch: pytest.MonkeyPatch, capsys
-):
-    """``--backend binary`` with a zeroed-out version (e.g. 0.0.0) shows the semantic-version error."""
-    monkeypatch.setattr(
-        sys,
-        "argv",
-        [
-            "clang-tools",
-            "install",
-            "clang-tidy",
-            "--version",
-            "0.0.0",
-            "--backend",
-            "binary",
-        ],
-    )
-    exit_code = main()
-    result = capsys.readouterr()
-    assert "not a semantic" in result.err
-    assert exit_code == 1
-
-
-def test_main_install_backend_wheel_success(monkeypatch: pytest.MonkeyPatch, capsys):
-    """``--backend wheel`` with a tool name succeeds via mocked _wheel_install."""
-    monkeypatch.setattr(
-        "clang_tools.main._wheel_install",
-        lambda tools, ver: 0,
-    )
-    monkeypatch.setattr(
-        sys,
-        "argv",
-        ["clang-tools", "install", "clang-format", "--backend", "wheel"],
-    )
-    exit_code = main()
-    result = capsys.readouterr()
-    assert exit_code == 0
-    assert result.err == ""
-
-
-def test_main_install_backend_wheel_unsupported_tool(
-    monkeypatch: pytest.MonkeyPatch, capsys
-):
-    """``--backend wheel`` with a binary-only tool name shows error."""
-    monkeypatch.setattr(
-        sys,
-        "argv",
-        ["clang-tools", "install", "clang-query", "--backend", "wheel"],
-    )
-    exit_code = main()
-    result = capsys.readouterr()
-    assert "is not available as a wheel" in result.err
-    assert exit_code == 1
-
-
-def test_main_install_backend_wheel_include_cleaner(
-    monkeypatch: pytest.MonkeyPatch, capsys
-):
-    """``--backend wheel`` with clang-include-cleaner succeeds."""
-    monkeypatch.setattr(
-        "clang_tools.main._wheel_install",
-        lambda tools, ver: 0,
-    )
-    monkeypatch.setattr(
-        sys,
-        "argv",
-        ["clang-tools", "install", "clang-include-cleaner", "--backend", "wheel"],
-    )
-    exit_code = main()
-    result = capsys.readouterr()
-    assert exit_code == 0
-    assert result.err == ""
-
-
-def test_main_install_backend_wheel_failure(monkeypatch: pytest.MonkeyPatch, capsys):
-    """``--backend wheel`` with a failing _wheel_install returns 1."""
-    monkeypatch.setattr("clang_tools.main._wheel_install", lambda tools, ver: 1)
-    monkeypatch.setattr(
-        sys,
-        "argv",
-        ["clang-tools", "install", "clang-format", "--backend", "wheel"],
-    )
-    exit_code = main()
-    assert exit_code == 1
-
-
-def test_main_install_backend_wheel_version_arg(
-    monkeypatch: pytest.MonkeyPatch, capsys
-):
-    """``--backend wheel`` with ``--version`` passes version to _wheel_install."""
-    tracked_version = []
-
-    def mock_wheel(tools, version):
-        tracked_version.append((tools, version))
-        return 0
-
-    monkeypatch.setattr("clang_tools.main._wheel_install", mock_wheel)
-    monkeypatch.setattr(
-        sys,
-        "argv",
-        [
-            "clang-tools",
-            "install",
-            "clang-format",
-            "--backend",
-            "wheel",
-            "--version",
-            "15.0.7",
-        ],
-    )
-    exit_code = main()
-    assert exit_code == 0
-    assert tracked_version == [(["clang-format"], "15.0.7")]
-
-
-def test_main_install_auto_no_version(monkeypatch: pytest.MonkeyPatch, capsys):
+def test_main_install_no_version(monkeypatch: pytest.MonkeyPatch, capsys):
     """Auto-detect without --version goes to wheel install."""
     tracked_install: list = []
 
@@ -282,7 +110,113 @@ def test_main_install_auto_no_version(monkeypatch: pytest.MonkeyPatch, capsys):
     assert tracked_install == [(["clang-tidy"], None)]
 
 
-def test_main_install_auto_new_wheel_tools(monkeypatch: pytest.MonkeyPatch, capsys):
+def test_main_install_with_version_success(
+    monkeypatch: pytest.MonkeyPatch, capsys, tmp_path
+):
+    """Auto-detect with --version tries binary first (succeeds)."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "clang-tools",
+            "install",
+            "clang-format",
+            "--version",
+            "12",
+            "--directory",
+            str(tmp_path),
+            "--no-progress-bar",
+        ],
+    )
+    exit_code = main()
+    assert exit_code == 0
+    bin_path = tmp_path / f"clang-format-12{suffix}"
+    assert bin_path.exists()
+
+
+def test_main_install_with_version_fallback(
+    monkeypatch: pytest.MonkeyPatch, capsys, tmp_path
+):
+    """Auto-detect with --version falls back to wheel when binary fails."""
+    monkeypatch.setattr("clang_tools.install.binary_repo", "not-a-valid-url")
+    monkeypatch.setattr(
+        "clang_tools.main._wheel_install",
+        lambda tools, ver: 0,
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "clang-tools",
+            "install",
+            "clang-tidy",
+            "--version",
+            "12",
+            "--no-progress-bar",
+        ],
+    )
+    exit_code = main()
+    result = capsys.readouterr()
+    assert exit_code == 0
+    assert "falling back to wheel" in result.err
+
+
+def test_main_install_with_version_out_of_range(
+    monkeypatch: pytest.MonkeyPatch, capsys
+):
+    """Auto-detect with out-of-range version falls back to wheel."""
+    tracked: list = []
+
+    def mock_wheel(tools, version):
+        tracked.append((tools, version))
+        return 0
+
+    monkeypatch.setattr("clang_tools.main._wheel_install", mock_wheel)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "clang-tools",
+            "install",
+            "clang-format",
+            "--version",
+            "99",
+        ],
+    )
+    exit_code = main()
+    assert exit_code == 0
+    assert tracked == [(["clang-format"], "99")]
+
+
+def test_main_install_with_version_bad_semver(
+    monkeypatch: pytest.MonkeyPatch, capsys
+):
+    """Auto-detect with 0.0.0 falls back to wheel."""
+    tracked: list = []
+
+    def mock_wheel(tools, version):
+        tracked.append((tools, version))
+        return 0
+
+    monkeypatch.setattr("clang_tools.main._wheel_install", mock_wheel)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "clang-tools",
+            "install",
+            "clang-tidy",
+            "--version",
+            "0.0.0",
+        ],
+    )
+    exit_code = main()
+    assert exit_code == 0
+    assert tracked == [(["clang-tidy"], "0.0.0")]
+
+
+def test_main_install_new_wheel_tools(monkeypatch: pytest.MonkeyPatch, capsys):
     """Auto-detect treats clang-include-cleaner / clang-apply-replacements as wheel."""
     tracked = []
 
@@ -308,113 +242,7 @@ def test_main_install_auto_new_wheel_tools(monkeypatch: pytest.MonkeyPatch, caps
     ]
 
 
-def test_main_install_auto_with_version_success(
-    monkeypatch: pytest.MonkeyPatch, capsys, tmp_path
-):
-    """Auto-detect: tool name + --version tries binary first (succeeds)."""
-    monkeypatch.chdir(tmp_path)
-    monkeypatch.setattr(
-        sys,
-        "argv",
-        [
-            "clang-tools",
-            "install",
-            "clang-format",
-            "--version",
-            "12",
-            "--directory",
-            str(tmp_path),
-            "--no-progress-bar",
-        ],
-    )
-    exit_code = main()
-    assert exit_code == 0
-    bin_path = tmp_path / f"clang-format-12{suffix}"
-    assert bin_path.exists()
-
-
-def test_main_install_auto_with_version_fallback(
-    monkeypatch: pytest.MonkeyPatch, capsys, tmp_path
-):
-    """Auto-detect: tool name + --version falls back to wheel when binary fails."""
-    monkeypatch.setattr("clang_tools.install.binary_repo", "not-a-valid-url")
-    monkeypatch.setattr(
-        "clang_tools.main._wheel_install",
-        lambda tools, ver: 0,
-    )
-    monkeypatch.setattr(
-        sys,
-        "argv",
-        [
-            "clang-tools",
-            "install",
-            "clang-tidy",
-            "--version",
-            "12",
-            "--no-progress-bar",
-        ],
-    )
-    exit_code = main()
-    result = capsys.readouterr()
-    assert exit_code == 0
-    assert "falling back to wheel" in result.err
-
-
-def test_main_install_auto_with_version_out_of_range(
-    monkeypatch: pytest.MonkeyPatch, capsys
-):
-    """Auto-detect: tool + --version with out-of-range version falls back to wheel."""
-    tracked: list = []
-
-    def mock_wheel(tools, version):
-        tracked.append((tools, version))
-        return 0
-
-    monkeypatch.setattr("clang_tools.main._wheel_install", mock_wheel)
-    monkeypatch.setattr(
-        sys,
-        "argv",
-        [
-            "clang-tools",
-            "install",
-            "clang-format",
-            "--version",
-            "99",
-        ],
-    )
-    exit_code = main()
-    assert exit_code == 0
-    assert tracked == [(["clang-format"], "99")]
-
-
-def test_main_install_auto_with_version_bad_semver(
-    monkeypatch: pytest.MonkeyPatch, capsys
-):
-    """Auto-detect: tool + --version with 0.0.0 falls back to wheel."""
-    tracked: list = []
-
-    def mock_wheel(tools, version):
-        tracked.append((tools, version))
-        return 0
-
-    monkeypatch.setattr("clang_tools.main._wheel_install", mock_wheel)
-    monkeypatch.setattr(
-        sys,
-        "argv",
-        [
-            "clang-tools",
-            "install",
-            "clang-tidy",
-            "--version",
-            "0.0.0",
-        ],
-    )
-    exit_code = main()
-    assert exit_code == 0
-    assert tracked == [(["clang-tidy"], "0.0.0")]
-
-
-def test_main_install_auto_unsupported_tool(monkeypatch: pytest.MonkeyPatch, capsys):
+def test_main_install_unsupported_tool(monkeypatch: pytest.MonkeyPatch, capsys):
     """Auto-detect with a binary-only tool name shows error."""
     monkeypatch.setattr(
         sys,
@@ -427,7 +255,7 @@ def test_main_install_auto_unsupported_tool(monkeypatch: pytest.MonkeyPatch, cap
     assert exit_code == 1
 
 
-def test_main_install_auto_multiple_tools(
+def test_main_install_multiple_tools(
     monkeypatch: pytest.MonkeyPatch, capsys, tmp_path
 ):
     """Auto-detect: multiple tool names with --version."""
@@ -600,33 +428,3 @@ def test_wheel_install_multiple_tools_mixed(monkeypatch: pytest.MonkeyPatch, cap
     result = capsys.readouterr()
     assert "installed at: /fake/clang-format" in result.out
     assert "TEST_ERROR: failed" in result.err
-
-
-# ---------------------------------------------------------------------------
-#  --backend binary fallback tests
-# ---------------------------------------------------------------------------
-
-
-def test_main_install_backend_binary_download_error(
-    monkeypatch: pytest.MonkeyPatch, capsys
-):
-    """``--backend binary`` that fails reports the error and returns 1."""
-    monkeypatch.setattr("clang_tools.install.binary_repo", "not-a-valid-url")
-    monkeypatch.setattr(
-        sys,
-        "argv",
-        [
-            "clang-tools",
-            "install",
-            "clang-format",
-            "--version",
-            "12",
-            "--backend",
-            "binary",
-            "--no-progress-bar",
-        ],
-    )
-    exit_code = main()
-    result = capsys.readouterr()
-    assert exit_code == 1
-    assert "Binary install failed" in result.err


### PR DESCRIPTION
## Description

Redesigns the CLI interface based on the design review of #194. Fixes #194 and #195

## Motivation

The old CLI had several design problems (see [detailed review](https://github.com/cpp-linter/clang-tools-pip/pull/197)):
- **Fragile positional arg detection**: used `_is_version_like()` to guess whether the positional arg is a version or tool name
- **Inconsistent default behavior**: `clang-tools install 18` installed 2 tools (via `--tool` default), but `clang-tools install clang-format` installed 1
- **Two syntaxes with different code paths**: `install 18 --tool clang-format` and `install clang-format --version 18` did different things
- **`--binary`/ `--wheel` naming**: ambiguous about what each does
- **Uninstall asymmetry**: version was positional, tools were flags

## New Design

### Install

```bash
# Positional args are always tool names
clang-tools install clang-format
clang-tools install clang-format clang-tidy

# Version is always via --version
clang-tools install clang-format --version 18

# Explicit backend via --backend
clang-tools install clang-format --version 18 
clang-tools install clang-format

# Auto-detect (default): binary first (if --version given), fall back to wheel
clang-tools install clang-include-cleaner --version 22
```

### Uninstall

```bash
# Tools are positional, --version is required
clang-tools uninstall clang-format --version 12
clang-tools uninstall clang-format clang-tidy --version 12
```

## Key Changes

| Old | New |
|-----|-----|
| `install <version>` | `install <tool> [<tool> ...] --version <VER>` |
| `--tool` flag | Removed (tools are positional args) |
| `uninstall <version> -t <tool>` | `uninstall <tool> --version <VER>` |
| `_is_version_like()` heuristic | Removed (no ambiguity) |

## Tests

- Updated all existing tests for the new CLI syntax
- Added tests for: multiple tools, unsupported tool in auto-detect

All 155 tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Install and uninstall commands now accept multiple tools as arguments.
  * Auto-detection now attempts binary installation first, with automatic fallback to wheel if binary fails.

* **Refactor**
  * Install command interface redesigned for multi-tool support and explicit version handling.
  * Uninstall command now requires `--version` as an explicit argument instead of positional parameter.

* **Tests**
  * Expanded test coverage for CLI parser behavior and backend selection logic.
  * Added tests for auto-detection fallback scenarios and multi-tool installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->