### PR TITLE
feat: add clang-tools --version support

### DIFF
--- a/clang_tools/main.py
+++ b/clang_tools/main.py
@@ -185,13 +185,9 @@ def get_parser() -> argparse.ArgumentParser:
 
 def _print_version() -> None:
     """Print the installed version of clang-tools-pip and exit."""
-    try:
-        from importlib.metadata import version
+    from importlib.metadata import version
 
-        ver = version("clang-tools")
-    except ImportError:
-        ver = "unknown"
-    print(f"clang-tools {ver}")
+    print(f"clang-tools {version('clang-tools')}")
 
 
 def main() -> int:

--- a/clang_tools/main.py
+++ b/clang_tools/main.py
@@ -177,11 +177,28 @@ def get_parser() -> argparse.ArgumentParser:
 # ---------------------------------------------------------------------------
 
 
+def _print_version() -> None:
+    """Print the installed version of clang-tools-pip and exit."""
+    try:
+        from importlib.metadata import version
+
+        ver = version("clang-tools")
+    except ImportError:
+        ver = "unknown"
+    print(f"clang-tools {ver}")
+
+
 def main() -> int:
     """Unified entry point for the CLI program.
 
     :returns: exit code (0 on success, 1 on failure).
     """
+    # Handle ``--version`` at the root level before argparse to avoid
+    # conflicting with ``install --version``.
+    if len(sys.argv) == 2 and sys.argv[1] in ("--version", "-V"):
+        _print_version()
+        return 0
+
     parser = get_parser()
     args = parser.parse_args()
 

--- a/clang_tools/main.py
+++ b/clang_tools/main.py
@@ -169,6 +169,12 @@ def get_parser() -> argparse.ArgumentParser:
         help="The directory from which to uninstall the tools.",
     )
 
+    # --- ``clang-tools version`` ------------------------------------------
+    subparsers.add_parser(
+        "version",
+        help="Show the clang-tools package version",
+    )
+
     return parser
 
 
@@ -216,6 +222,10 @@ def main() -> int:
 
     if args.command == "uninstall":
         uninstall_clang_tools(args.tools, args.version, args.directory)
+        return 0
+
+    if args.command == "version":
+        _print_version()
         return 0
 
     return 0  # unreachable

--- a/docs/cli_args.md
+++ b/docs/cli_args.md
@@ -73,4 +73,3 @@ The directory from which to uninstall the tools.
     clang-tools version [-h]
 
 ```
-

--- a/docs/cli_args.md
+++ b/docs/cli_args.md
@@ -7,7 +7,7 @@ title: clang-tools CLI
 ## Usage
 
 ```text
-    clang-tools [-h] {install,uninstall} ...
+    clang-tools [-h] {install,uninstall,version} ...
 ```
 
 ---
@@ -64,3 +64,13 @@ Version to uninstall (e.g. 18)
 :material-tag-outline: **v0.2.0** &nbsp; Default: ``
 
 The directory from which to uninstall the tools.
+
+---
+
+## `clang-tools version`
+
+```text
+    clang-tools version [-h]
+
+```
+

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -89,6 +89,49 @@ def test_main_no_args(monkeypatch: pytest.MonkeyPatch, capsys):
     assert exit_code == 0
 
 
+def test_main_version(monkeypatch: pytest.MonkeyPatch, capsys):
+    """``clang-tools --version`` prints package version."""
+    monkeypatch.setattr(sys, "argv", ["clang-tools", "--version"])
+    exit_code = main()
+    result = capsys.readouterr()
+    assert "clang-tools" in result.out
+    assert exit_code == 0
+
+
+def test_main_version_short(monkeypatch: pytest.MonkeyPatch, capsys):
+    """``clang-tools -V`` prints package version."""
+    monkeypatch.setattr(sys, "argv", ["clang-tools", "-V"])
+    exit_code = main()
+    result = capsys.readouterr()
+    assert "clang-tools" in result.out
+    assert exit_code == 0
+
+
+def test_main_version_does_not_conflict_with_install(
+    monkeypatch: pytest.MonkeyPatch, capsys, tmp_path
+):
+    """``clang-tools install --version 12`` still works (not confused with root --version)."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "clang-tools",
+            "install",
+            "clang-format",
+            "--version",
+            "12",
+            "--directory",
+            str(tmp_path),
+            "--no-progress-bar",
+        ],
+    )
+    exit_code = main()
+    assert exit_code == 0
+    bin_path = tmp_path / f"clang-format-12{suffix}"
+    assert bin_path.exists()
+
+
 def test_main_install_no_version(monkeypatch: pytest.MonkeyPatch, capsys):
     """Auto-detect without --version goes to wheel install."""
     tracked_install: list = []

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -107,6 +107,15 @@ def test_main_version_short(monkeypatch: pytest.MonkeyPatch, capsys):
     assert exit_code == 0
 
 
+def test_main_version_subcommand(monkeypatch: pytest.MonkeyPatch, capsys):
+    """``clang-tools version`` prints package version."""
+    monkeypatch.setattr(sys, "argv", ["clang-tools", "version"])
+    exit_code = main()
+    result = capsys.readouterr()
+    assert "clang-tools" in result.out
+    assert exit_code == 0
+
+
 def test_main_version_does_not_conflict_with_install(
     monkeypatch: pytest.MonkeyPatch, capsys, tmp_path
 ):


### PR DESCRIPTION
## Description

Fixes #196.

Adds `clang-tools --version` (and `-V`) support to print the installed package version.

## Implementation

- Handles `--version` at the root level in `main()` by checking `sys.argv` before argparse, to avoid conflicting with `install --version` (used for specifying the tool version to install).
- Uses `importlib.metadata.version('clang-tools')` to read the version set dynamically by setuptools-scm.
- Added tests for `--version`, `-V`, and a conflict test ensuring `install --version 12` still works.

## Usage



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `clang-tools version` subcommand to display installed package version.
  * Added support for `--version` and `-V` root-level arguments.

* **Documentation**
  * Updated CLI documentation to reflect new version command and flags.

* **Tests**
  * Added test coverage for version command and flag behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->